### PR TITLE
Check gdk_event_get_scroll_deltas() when scrolling menus.

### DIFF
--- a/packages/gtk+.py
+++ b/packages/gtk+.py
@@ -83,6 +83,7 @@ class GtkPackage (GnomeGitPackage):
 				'patches/gtk/0066-cellrendererpixbuf-let-2x-variants-go-through-pixel-.patch',
 				'patches/gtk/0067-quartz-Make-event-loop-deal-with-recursive-poll-invo.patch',
 				'patches/gtk/0068-nsview-implement-a-few-text-view-command-accelerator.patch',
+				'patches/gtk/0069-menu-scrolling.patch',
 
 				# Bug 702841 - GdkQuartz does not distinguish Eisu, Kana and Space keys on Japanese keyrboard
 				# https://bugzilla.gnome.org/show_bug.cgi?id=702841

--- a/packages/patches/gtk/0069-menu-scrolling.patch
+++ b/packages/patches/gtk/0069-menu-scrolling.patch
@@ -1,0 +1,47 @@
+diff --git a/gtk/gtkmenu.c b/gtk/gtkmenu.c
+index fc25098..de9a4b0 100644
+--- a/gtk/gtkmenu.c
++++ b/gtk/gtkmenu.c
+@@ -55,6 +55,7 @@
+ #define MENU_SCROLL_FAST_ZONE  8
+ #define MENU_SCROLL_TIMEOUT1  50
+ #define MENU_SCROLL_TIMEOUT2  20
++#define GTK_SCROLL_STEP_SMOOTH 2
+ 
+ #define ATTACH_INFO_KEY "gtk-menu-child-attach-info-key"
+ #define ATTACHED_MENUS "gtk-attached-menus"
+@@ -3504,17 +3505,25 @@ gtk_menu_scroll (GtkWidget	*widget,
+ 		 GdkEventScroll *event)
+ {
+   GtkMenu *menu = GTK_MENU (widget);
++  gdouble dx, dy;
+ 
+-  switch (event->direction)
++  if (gdk_event_get_scroll_deltas ((GdkEvent *) event, &dx, &dy))
+     {
+-    case GDK_SCROLL_RIGHT:
+-    case GDK_SCROLL_DOWN:
+-      gtk_menu_scroll_by (menu, MENU_SCROLL_STEP2);
+-      break;
+-    case GDK_SCROLL_LEFT:
+-    case GDK_SCROLL_UP:
+-      gtk_menu_scroll_by (menu, - MENU_SCROLL_STEP2);
+-      break;
++      gtk_menu_scroll_by (menu, GTK_SCROLL_STEP_SMOOTH * dy);
++    }
++  else
++    {
++      switch (event->direction)
++        {
++        case GDK_SCROLL_RIGHT:
++        case GDK_SCROLL_DOWN:
++          gtk_menu_scroll_by (menu, MENU_SCROLL_STEP2);
++          break;
++        case GDK_SCROLL_LEFT:
++        case GDK_SCROLL_UP:
++          gtk_menu_scroll_by (menu, - MENU_SCROLL_STEP2);
++          break;
++        }
+     }
+ 
+   return TRUE;


### PR DESCRIPTION
This fixes unusual scrolling behavior on Mac when using trackpad or magic mouse
smooth scrolling on large popup menus.

Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=13827
