### PR TITLE
Let keyboard hotkeys defined in the user preferences pass through

### DIFF
--- a/packages/gtk+.py
+++ b/packages/gtk+.py
@@ -86,6 +86,7 @@ class GtkPackage (GnomeGitPackage):
 				'patches/gtk/0069-menu-scrolling.patch',
 				'patches/gtk/0070-tooltips-focus.patch',
 				'patches/gtk/0071-light-and-dark-overlay-scrollbars.patch',
+				'patches/gtk/0072-let-global-keyboard-shortcuts-pass-through.patch',
 
 				# Bug 702841 - GdkQuartz does not distinguish Eisu, Kana and Space keys on Japanese keyrboard
 				# https://bugzilla.gnome.org/show_bug.cgi?id=702841

--- a/packages/patches/gtk/0072-let-global-keyboard-shortcuts-pass-through.patch
+++ b/packages/patches/gtk/0072-let-global-keyboard-shortcuts-pass-through.patch
@@ -1,0 +1,59 @@
+diff --git a/gdk/quartz/gdkkeys-quartz.c b/gdk/quartz/gdkkeys-quartz.c
+index a034bbd..2169428 100644
+--- a/gdk/quartz/gdkkeys-quartz.c
++++ b/gdk/quartz/gdkkeys-quartz.c
+@@ -812,9 +812,42 @@ gdk_keymap_map_virtual_modifiers (GdkKeymap       *keymap,
+ GdkEventType
+ _gdk_quartz_keys_event_type (NSEvent *event)
+ {
+-  unsigned short keycode;
+-  unsigned int flags;
++  unsigned short keycode = [event keyCode];
++  unsigned int flags = [event modifierFlags];
++  CFArrayRef global_keys = NULL;
+   int i;
++
++  if (CopySymbolicHotKeys (&global_keys) == noErr && global_keys != NULL)
++    {
++      CFIndex length = CFArrayGetCount (global_keys);
++
++      for (i = 0; i < length; i++)
++	{
++	  CFDictionaryRef key_info = CFArrayGetValueAtIndex (global_keys, i);
++
++	  CFNumberRef code = CFDictionaryGetValue (key_info, kHISymbolicHotKeyCode);
++	  CFNumberRef mods = CFDictionaryGetValue (key_info, kHISymbolicHotKeyModifiers);
++	  CFBooleanRef enabled = CFDictionaryGetValue (key_info, kHISymbolicHotKeyEnabled);
++
++	  gint32 mod_value;
++	  gushort tmp_keycode;
++
++	  CFNumberGetValue (mods, kCFNumberSInt32Type, &mod_value);
++	  CFNumberGetValue (code, kCFNumberShortType, &tmp_keycode);
++
++	  if (CFBooleanGetValue (enabled) && keycode == tmp_keycode)
++	    {
++	      if ((!!(mod_value & (1 << cmdKeyBit)) == !!(flags & NSCommandKeyMask)) &&
++		  (!!(mod_value & (1 << controlKeyBit)) == !!(flags & NSControlKeyMask)) &&
++		  (!!(mod_value & (1 << shiftKeyBit)) == !!(flags & NSShiftKeyMask)))
++		{
++		  return GDK_NOTHING;
++		}
++	    }
++	}
++    }
++
++    CFRelease (global_keys);
+   
+   switch ([event type])
+     {
+@@ -830,9 +863,6 @@ _gdk_quartz_keys_event_type (NSEvent *event)
+   
+   /* For flags-changed events, we have to find the special key that caused the
+    * event, and see if it's in the modifier mask. */
+-  keycode = [event keyCode];
+-  flags = [event modifierFlags];
+-  
+   for (i = 0; i < G_N_ELEMENTS (modifier_keys); i++)
+     {
+       if (modifier_keys[i].keycode == keycode)


### PR DESCRIPTION
Let keyboard hotkeys defined in the user preferences pass through without generating a GdkEvent.

https://bugzilla.xamarin.com/show_bug.cgi?id=441
