### PR TITLE
Update mono config generation

### DIFF
--- a/packages/mono-master.py
+++ b/packages/mono-master.py
@@ -21,6 +21,7 @@ class MonoMasterPackage(Package):
 					])
 
 			self.configure_flags.extend([
+				'--with-libgdiplus=%s/lib/libgdiplus.dylib' % Package.profile.prefix,
 				'--enable-loadedllvm'
 				])
 
@@ -28,6 +29,10 @@ class MonoMasterPackage(Package):
 					# Fixes up pkg-config usage on the Mac
 					'patches/mcs-pkgconfig.patch'
 					])
+		else:
+			self.configure_flags.extend([
+				'--with-libgdiplus=%s/lib/libgdiplus.so' % Package.profile.prefix,
+				])
 
 		self.configure = expand_macros ('CFLAGS="%{env.CFLAGS} -O2" ./autogen.sh', Package.profile)
 

--- a/profiles/mono-mac-release/mono-mac-release.py
+++ b/profiles/mono-mac-release/mono-mac-release.py
@@ -217,11 +217,6 @@ class MonoReleaseProfile(DarwinProfile, MonoReleasePackages):
         os.rename(temp, config)
         os.system('chmod a+r %s' % config)
 
-    def fix_libMonoPosixHelper(self):
-        config = os.path.join(self.prefix, "etc", "mono", "config")
-        self.fix_dllmap(
-            config, lambda line: "libMonoPosixHelper.dylib" in line)
-
     def fix_gtksharp_configs(self):
         libs = [
             'atk-sharp',
@@ -240,7 +235,6 @@ class MonoReleaseProfile(DarwinProfile, MonoReleasePackages):
 
     # THIS IS THE MAIN METHOD FOR MAKING A PACKAGE
     def package(self):
-        self.fix_libMonoPosixHelper()
         self.fix_gtksharp_configs()
         self.generate_dsym()
         blacklist = os.path.join(self.packaging_dir, 'mdk_blacklist.sh')


### PR DESCRIPTION
Mono PR mono/mono#1064 changes how the paths for libMonoPosixHelper and
libgdiplus stored in the configuration file are computed. This means
that no fixing is needed anymore for libMonoPosixHelper, because the
intallation prefix is automatically added. Instead libgdiplus is
assumed to be in the default library load path unless another path is
specified at configure-time through the --with-libgdiplus option.
