### PR TITLE
Add Xamarin.Mac to supported framework files for PCLs

### DIFF
--- a/packages/pcl-reference-assemblies.py
+++ b/packages/pcl-reference-assemblies.py
@@ -44,7 +44,7 @@ class PCLReferenceAssembliesPackage(Package):
             os.path.join(directory, "Xamarin.Android.xml"):
             """<Framework Identifier="MonoAndroid" MinimumVersion="1.0" Profile="*" DisplayName="Xamarin.Android"/>""",
             os.path.join(directory, "Xamarin.Mac.xml"):
-            """<Framework Identifier="Xamarin.Mac" MinimumVersion="1.0" Profile="*" DisplayName="Xamarin.Mac Unified"/>""",
+            """<Framework Identifier="Xamarin.Mac" MinimumVersion="2.0" Profile="*" DisplayName="Xamarin.Mac Unified"/>""",
         }
         for filename, content in data.iteritems():
             f = open(filename, "w")


### PR DESCRIPTION
@jstedfast added the new Xamarin.iOS unified framework to the PCL profile xml files in another [commit](https://github.com/mono/bockbuild/commit/f2381976152a729728211adbbed61562bf887dec).

This pull request includes a change that adds the new Xamarin.Mac unified framework to the PCL profile xml files. This allows Xamarin Studio 5.4 to add the Json.NET NuGet package to a Xamarin.Mac unified project.
