### PR TITLE
[MonoMacRelease] Added a preinstall hook that removes the version of mono we are installing

### DIFF
--- a/profiles/mono-mac-release/packaging/preinstall.template
+++ b/profiles/mono-mac-release/packaging/preinstall.template
@@ -1,0 +1,7 @@
+#!/bin/sh -x
+
+PREVIOUS_INSTALL=/Library/Frameworks/Mono.framework/Versions/RELEASE_VERSION
+
+if [ -d $PREVIOUS_INSTALL ]; then
+  rm -rf $PREVIOUS_INSTALL
+fi


### PR DESCRIPTION
Ex:

```
$ cd 4.0.0
$ sudo touch LALALAL
$ ls
LALALAL    bin        docs       etc        lib        man        share      updateinfo
$ cd ../
$ open $BOCKBUILD_DIR/profiles/mono-mac-release/MonoFramework-MRE-4.0.0.macos10.xamarin.x86.pkg
......
$ ls 4.0.0
bin        docs       etc        lib        man        share      updateinfo 
```
