### PR TITLE
[Package] Stop assuming that default_sources must exist

### DIFF
--- a/bockbuild/package.py
+++ b/bockbuild/package.py
@@ -52,7 +52,7 @@ class Package:
 			and not self.__class__.default_sources == None:
 			self.sources = list (self.__class__.default_sources)
 
-		if self.organization == None:
+		if self.organization == None and self.sources != None and len(self.sources) > 0:
 			self.organization = self.extract_organization (self.sources[0])
 
 		self.source_dir_name = source_dir_name


### PR DESCRIPTION
If self.sources is None, it is tried to be initialized with the
value of the default_sources static field of its class, but there
may be classes which don't provide it.

The commit[1] that introduced the extract_organization() function
didn't take this in account.

This happens when we have a dummy package such as the gconf-one:
https://github.com/mono/bockbuild/blob/mono-3.4.0-branch/packages/gconf-dummy.py

And was exposed when running the banshee's darwin profile, as
evidenced by the stacktrace in [2].

[1] mono@43d1f7c
[2] https://bugzilla.gnome.org/show_bug.cgi?id=750110#c0