### PR TITLE
[DarwinProfile] Fix TypeError in debug build

### DIFF
--- a/bockbuild/darwinprofile.py
+++ b/bockbuild/darwinprofile.py
@@ -46,7 +46,7 @@ class DarwinProfile (UnixProfile):
 			self.env.set ('MACOSX_DEPLOYMENT_TARGET', self.target_osx)
 		
 		if self.cmd_options.debug is True:
-			self.gcc_flags.extend ('-O0', '-ggdb3')
+			self.gcc_flags.extend ([ '-O0', '-ggdb3' ])
 
 		if os.getenv('BOCKBUILD_USE_CCACHE') is None:
 			self.env.set ('CC',  'xcrun gcc')


### PR DESCRIPTION
Bockbuild was refactored in [1] and, as part of it, the
GCC flags -O0 and -ggdb3 were moved to be applied directly
the the self.gcc_flags (but only if self.cmd_options.debug).

But gcc_flags' extend method only allows 1 argument (array)
instead of N, like gcc_debug_flags.

So this commit fixes this regression, whose stacktrace can
be seen in this bug comment [2]

[1] https://github.com/mono/bockbuild/commit/00e0e8ec65f1f0dab3814621ae752ade2e57138c
[2] https://bugzilla.gnome.org/show_bug.cgi?id=750110#c1