### PR TITLE
Refactored patches for added safety

### DIFF
--- a/bockbuild/package.py
+++ b/bockbuild/package.py
@@ -423,6 +423,9 @@ class Package:
 
 			# self.deploy ()
 
+	def patch (self):
+		for patch in self.patches:
+			patch.run (self)
 
 	def do_build (self, arch, install_prefix, workspace_dir, stage_root = None):
 
@@ -443,6 +446,7 @@ class Package:
 			self.verbose = True #log sh() uses while in package logic
 		self.arch_build (arch)
 		self.prep ()
+		self.patch ()
 		self.build ()
 		self.install ()
 

--- a/bockbuild/package.py
+++ b/bockbuild/package.py
@@ -9,6 +9,16 @@ import stat
 from urllib import FancyURLopener
 from util.util import *
 
+class Patches ():
+	def __init__ (self, patches, shared_options):
+		self.contents = []
+		for path in patches:
+			self.contents.append (Patch (path, options = shared_options))
+
+	def run (self, pkg):
+		for patch in self.contents:
+			patch.run (pkg)
+
 class Patch ():
 	def __init__ (self, rel_path, options = '-p0', patch_cmd = 'patch'):
 		self.rel_path = rel_path

--- a/packages/banshee-git.py
+++ b/packages/banshee-git.py
@@ -11,8 +11,5 @@ class BansheePackage (Package):
 		self.sources.extend([
 		])
 
-	def prep (self):
-		Package.prep (self)
-		#self.sh ('patch -p1 < %{sources[1]}')
 
 BansheePackage ()

--- a/packages/banshee.py
+++ b/packages/banshee.py
@@ -11,7 +11,7 @@ class BansheePackage (Package):
 		self.sources.extend([
 
 			# switch over from ige_* to gtk_* binding
-			'patches/banshee-gtk-mac-integration.patch'
+			Patch('patches/banshee-gtk-mac-integration.patch', '-p1')
 		])
 
 	def prep (self):

--- a/packages/banshee.py
+++ b/packages/banshee.py
@@ -14,8 +14,4 @@ class BansheePackage (Package):
 			Patch('patches/banshee-gtk-mac-integration.patch', '-p1')
 		])
 
-	def prep (self):
-		Package.prep (self)
-		self.sh ('patch -p1 < %{sources[1]}')
-
 BansheePackage ()

--- a/packages/cairo.py
+++ b/packages/cairo.py
@@ -1,9 +1,6 @@
 class CairoPackage (CairoGraphicsXzPackage):
 	def __init__ (self):
 		CairoGraphicsXzPackage.__init__ (self, 'cairo', '1.12.14')
-	def prep (self):
-		Package.prep (self)
-
 		if Package.profile.name == 'darwin':
 			self.sources.extend ([
 				Patch('patches/cairo-quartz-crash.patch', options = '-p1'),

--- a/packages/cairo.py
+++ b/packages/cairo.py
@@ -1,19 +1,16 @@
 class CairoPackage (CairoGraphicsXzPackage):
 	def __init__ (self):
 		CairoGraphicsXzPackage.__init__ (self, 'cairo', '1.12.14')
-		self.sources.extend ([
-			'patches/cairo-quartz-crash.patch',
-			'patches/cairo-fix-color-bitmap-fonts.patch',
-			'patches/cairo-fix-CGFontGetGlyphPath-deprecation.patch',
-#			'patches/cairo-cglayer.patch',
-		])
-
 	def prep (self):
 		Package.prep (self)
 
 		if Package.profile.name == 'darwin':
-			for p in range (1, len (self.local_sources)):
-				self.sh ('patch -p1 < "%{local_sources[' + str (p) + ']}"')
+			self.sources.extend ([
+				Patch('patches/cairo-quartz-crash.patch', options = '-p1'),
+				Patch('patches/cairo-fix-color-bitmap-fonts.patch', options = '-p1'),
+				Patch('patches/cairo-fix-CGFontGetGlyphPath-deprecation.patch', options = '-p1'),
+	#			'Patch(patches/cairo-cglayer.patch', options = '-p1'),
+			])
 
 	def build (self):
 		self.configure_flags = [

--- a/packages/fsharp-3.1.py
+++ b/packages/fsharp-3.1.py
@@ -7,13 +7,14 @@ class Fsharp31Package(GitHubTarballPackage):
 			'1f79c0455fb8b5ec816985f922413894ce19359a',
 			configure = './configure --prefix="%{package_prefix}"')
 		self.sources.extend ([
-			'patches/fsharp-fix-net45-profile.patch'])
+			Patch ('patches/fsharp-fix-net45-profile.patch', options = '-p1')
+		])
 
 	def prep(self):
 		Package.prep (self)
 
-		for p in range (1, len (self.sources)):
-				self.sh ('patch -p1 < "%{local_sources[' + str (p) + ']}"')
+		for p in self.patches:
+			p.run (self)
 
 
 	def build(self):

--- a/packages/fsharp-3.1.py
+++ b/packages/fsharp-3.1.py
@@ -10,13 +10,6 @@ class Fsharp31Package(GitHubTarballPackage):
 			Patch ('patches/fsharp-fix-net45-profile.patch', options = '-p1')
 		])
 
-	def prep(self):
-		Package.prep (self)
-
-		for p in self.patches:
-			p.run (self)
-
-
 	def build(self):
 		self.sh ('autoreconf')
 		Package.configure (self)

--- a/packages/gdk-pixbuf.py
+++ b/packages/gdk-pixbuf.py
@@ -8,10 +8,4 @@ class GdkPixbufPackage (GnomeXzPackage):
 				Patch('patches/gdk-pixbuf/0001-pixbuf-Add-getter-setter-for-the-2x-variants.patch', options = '-p1 --ignore-whitespace'),
 			])
 
-	def prep (self):
-		Package.prep (self)
-		if Package.profile.name == 'darwin':
-			for p in self.patches:
-				p.run (self)
-
 GdkPixbufPackage ()

--- a/packages/gdk-pixbuf.py
+++ b/packages/gdk-pixbuf.py
@@ -4,14 +4,14 @@ class GdkPixbufPackage (GnomeXzPackage):
 
 		if Package.profile.name == 'darwin':
 			self.sources.extend ([
-				'patches/gdk-pixbuf/0001-pixbuf-load-2x-variants-as-pixbuf-gobject-data.patch',
-				'patches/gdk-pixbuf/0001-pixbuf-Add-getter-setter-for-the-2x-variants.patch',
+				Patch('patches/gdk-pixbuf/0001-pixbuf-load-2x-variants-as-pixbuf-gobject-data.patch', options = '-p1 --ignore-whitespace'),
+				Patch('patches/gdk-pixbuf/0001-pixbuf-Add-getter-setter-for-the-2x-variants.patch', options = '-p1 --ignore-whitespace'),
 			])
 
 	def prep (self):
 		Package.prep (self)
 		if Package.profile.name == 'darwin':
-			for p in range (1, len (self.local_sources)):
-				self.sh ('patch -p1 --ignore-whitespace < "%{local_sources[' + str (p) + ']}"')
+			for p in self.patches:
+				p.run (self)
 
 GdkPixbufPackage ()

--- a/packages/gettext.py
+++ b/packages/gettext.py
@@ -21,10 +21,4 @@ class GettextPackage (GnuPackage):
 				Patch('patches/gettext-no-samples.patch', options = '-p1'),
 			])
 
-	def prep (self):
-		Package.prep (self)
-		if Package.profile.name == 'darwin':
-			for p in self.patches:
-				p.run (self)
-
 GettextPackage ()

--- a/packages/gettext.py
+++ b/packages/gettext.py
@@ -18,13 +18,13 @@ class GettextPackage (GnuPackage):
 			self.sources.extend ([
 				# Don't build samples
 				# https://trac.macports.org/export/79183/trunk/dports/devel/gettext/files/patch-gettext-tools-Makefile.in
-				'patches/gettext-no-samples.patch',
+				Patch('patches/gettext-no-samples.patch', options = '-p1'),
 			])
 
 	def prep (self):
 		Package.prep (self)
 		if Package.profile.name == 'darwin':
-			for p in range (1, len (self.local_sources)):
-				self.sh ('patch -p1 < "%{local_sources[' + str (p) + ']}"')
+			for p in self.patches:
+				p.run (self)
 
 GettextPackage ()

--- a/packages/glib.py
+++ b/packages/glib.py
@@ -1,3 +1,4 @@
+
 class GlibPackage (GnomeXzPackage):
 	def __init__ (self):
 		GnomeXzPackage.__init__ (self,
@@ -11,32 +12,41 @@ class GlibPackage (GnomeXzPackage):
 			#link to specific revisions for glib 2.30.x
 			self.sources.extend ([
 				# https://trac.macports.org/export/91680/trunk/dports/devel/glib2/files/config.h.ed
+				# This string-only description is not a bug, this patch is applied during the build step.
+				# So we don't track it as one of our patches.
 				'patches/glib/config.h.ed',
+
 				# https://trac.macports.org/export/98985/trunk/dports/devel/glib2/files/patch-configure.diff
-				'patches/glib/patch-configure.diff',
+				Patch('patches/glib/patch-configure.diff', options = '-p0'),
 				# https://trac.macports.org/export/42728/trunk/dports/devel/glib2/files/patch-gi18n.h.diff
-				'patches/glib/patch-gi18n.h.diff',
+				Patch('patches/glib/patch-gi18n.h.diff', options = '-p0'),
 				# https://trac.macports.org/export/92608/trunk/dports/devel/glib2/files/patch-gio_gdbusprivate.c.diff
-				'patches/glib/patch-gio_gdbusprivate.c.diff',
+				Patch('patches/glib/patch-gio_gdbusprivate.c.diff', options = '-p0'),
 				# https://trac.macports.org/export/49466/trunk/dports/devel/glib2/files/patch-gio_xdgmime_xdgmime.c.diff
-				'patches/glib/patch-gio_xdgmime_xdgmime.c.diff',
+				Patch('patches/glib/patch-gio_xdgmime_xdgmime.c.diff', options = '-p0'),
 				# https://trac.macports.org/export/91680/trunk/dports/devel/glib2/files/patch-glib-2.0.pc.in.diff
-				'patches/glib/patch-glib-2.0.pc.in.diff',
+				Patch('patches/glib/patch-glib-2.0.pc.in.diff', options = '-p0'),
 				# https://trac.macports.org/export/64476/trunk/dports/devel/glib2/files/patch-glib_gunicollate.c.diff
-				'patches/glib/patch-glib_gunicollate.c.diff',
+				Patch('patches/glib/patch-glib_gunicollate.c.diff', options = '-p0'),
 
 				# Bug 6156 - [gtk] Quitting the application with unsaved file and answering Cancel results in crash
 				# https://bugzilla.xamarin.com/attachment.cgi?id=2214
-				'patches/glib-recursive-poll.patch',
+				Patch('patches/glib-recursive-poll.patch', options = '-p1 --ignore-whitespace'),
 			])
 
 	def prep (self):
 		Package.prep (self)
 		if self.darwin:
-			for p in range (2, 8):
-				self.sh ('patch -p0 < %{local_sources[' + str (p) + ']}')
-			for p in range (8, len (self.local_sources)):
-				self.sh ('patch --ignore-whitespace -p1 < %{local_sources[' + str (p) + ']}')
+			#for p in range (2, 8):
+				#print (self.local_sources[p])
+				##self.sh ('patch -p0 < %{local_sources[' + str (p) + ']}')
+			#for p in range (8, len (self.local_sources)):
+				#print (self.local_sources[p])
+				## This is bockbuild templating language
+				## Add new fetch -> patch -> prep step
+				##self.sh ('patch --ignore-whitespace -p1 < %{local_sources[' + str (p) + ']}')
+			for patch in self.patches:
+				patch.run (self)
 
 	def arch_build (self, arch):
 		if arch == 'darwin-universal': #multi-arch  build pass

--- a/packages/glib.py
+++ b/packages/glib.py
@@ -34,20 +34,6 @@ class GlibPackage (GnomeXzPackage):
 				Patch('patches/glib-recursive-poll.patch', options = '-p1 --ignore-whitespace'),
 			])
 
-	def prep (self):
-		Package.prep (self)
-		if self.darwin:
-			#for p in range (2, 8):
-				#print (self.local_sources[p])
-				##self.sh ('patch -p0 < %{local_sources[' + str (p) + ']}')
-			#for p in range (8, len (self.local_sources)):
-				#print (self.local_sources[p])
-				## This is bockbuild templating language
-				## Add new fetch -> patch -> prep step
-				##self.sh ('patch --ignore-whitespace -p1 < %{local_sources[' + str (p) + ']}')
-			for patch in self.patches:
-				patch.run (self)
-
 	def arch_build (self, arch):
 		if arch == 'darwin-universal': #multi-arch  build pass
 			self.local_ld_flags = ['-arch i386' , '-arch x86_64']

--- a/packages/gstreamer.py
+++ b/packages/gstreamer.py
@@ -8,9 +8,11 @@ class GstreamerBasePackage (GstreamerPackage):
                 self.configure = './configure --disable-gtk-doc --prefix="%{prefix}"'
 
                 # Mark pluginloader changes to be reverted 
-		self.sources.append ( 'http://cgit.freedesktop.org/gstreamer/gstreamer/patch/?id=f660536eb341767fbef0ccf1bf1139e2b4ce749c' )
-		self.sources.append ( 'http://cgit.freedesktop.org/gstreamer/gstreamer/patch/?id=918a62abcf7ae44b0bc84d57742d2f759e0d8ed6' )
-		self.sources.append ( 'http://cgit.freedesktop.org/gstreamer/gstreamer/patch/?id=159cf687a1b63f334ecec5e0b1ea4cd1bc8e7537' )  
+		self.sources.append ([
+                        Patch('http://cgit.freedesktop.org/gstreamer/gstreamer/patch/?id=f660536eb341767fbef0ccf1bf1139e2b4ce749c', options = '-p1 -R')
+                        Patch('http://cgit.freedesktop.org/gstreamer/gstreamer/patch/?id=918a62abcf7ae44b0bc84d57742d2f759e0d8ed6', options = '-p1 -R')
+                        Patch('http://cgit.freedesktop.org/gstreamer/gstreamer/patch/?id=159cf687a1b63f334ecec5e0b1ea4cd1bc8e7537', options = '-p1 -R')
+                ])
 
         def prep (self):
                 Package.prep (self)

--- a/packages/gstreamer.py
+++ b/packages/gstreamer.py
@@ -14,10 +14,4 @@ class GstreamerBasePackage (GstreamerPackage):
                         Patch('http://cgit.freedesktop.org/gstreamer/gstreamer/patch/?id=159cf687a1b63f334ecec5e0b1ea4cd1bc8e7537', options = '-p1 -R')
                 ])
 
-        def prep (self):
-                Package.prep (self)
-                self.sh ('patch -p1 -R < "%{sources[1]}"')
-                self.sh ('patch -p1 -R < "%{sources[2]}"')
-                self.sh ('patch -p1 -R < "%{sources[3]}"')
-
 GstreamerBasePackage ()

--- a/packages/gtk+.py
+++ b/packages/gtk+.py
@@ -10,164 +10,166 @@ class GtkPackage (GnomeGitPackage):
 
 		if Package.profile.name == 'darwin':
 			self.gdk_target = 'quartz'
+
+			default_patch_options = ' -p1 --ignore-whitespace '
 			self.sources.extend ([
 				# Custom gtkrc
 				'patches/gtkrc',
 
 				# smooth scrolling, scrollbars, overscroll, retina, gtknsview
-				'patches/gtk/0001-Add-invariant-that-a-child-is-unmapped-if-parent-is-.patch',
-				'patches/gtk/0002-Maintain-map-unmap-invariants-in-GtkRecentChooserDia.patch',
-				'patches/gtk/0003-GtkPlug-preserve-map-unmap-invariants.patch',
-				'patches/gtk/0004-Add-gdk_screen_get_monitor_workarea-and-use-it-all-o.patch',
-				'patches/gtk/0005-gtk-don-t-scroll-combo-box-menus-if-less-than-3-item.patch',
-				'patches/gtk/0006-gtk-paint-only-the-exposed-region-in-gdk_window_expo.patch',
-				'patches/gtk/0007-Implement-gtk-enable-overlay-scrollbars-GtkSetting.patch',
-				'patches/gtk/0008-Smooth-scrolling.patch',
-				'patches/gtk/0009-gtk-Add-a-way-to-do-event-capture.patch',
-				'patches/gtk/0010-gtk-don-t-let-insensitive-children-eat-scroll-events.patch',
-				'patches/gtk/0011-scrolledwindow-Kinetic-scrolling-support.patch',
-				'patches/gtk/0012-gtk-paint-to-the-right-windows-in-gtk_scrolled_windo.patch',
-				'patches/gtk/0013-GtkScrolledWindow-add-overlay-scrollbars.patch',
-				'patches/gtk/0014-gtk-add-event-handling-to-GtkScrolledWindow-s-overla.patch',
-				'patches/gtk/0015-Use-gtk-enable-overlay-scrollbars-in-GtkScrolledWind.patch',
-				'patches/gtk/0016-gtk-correctly-handle-toggling-of-the-scrollbar-visib.patch',
-				'patches/gtk/0017-gtk-handle-gtk-primary-button-warps-slider-for-the-o.patch',
-				'patches/gtk/0018-Introduce-phase-field-in-GdkEventScroll.patch',
-				'patches/gtk/0019-Add-hack-to-lock-flow-of-scroll-events-to-window-whe.patch',
-				'patches/gtk/0020-Introduce-a-background-window.patch',
-				'patches/gtk/0021-Make-scrolled-window-work-well-with-Mac-touchpad.patch',
-				'patches/gtk/0022-Use-start-end-phase-in-event-handling.patch',
-				'patches/gtk/0023-Improve-overshooting-behavior.patch',
-				'patches/gtk/0024-Cancel-out-smaller-delta-component.patch',
-				'patches/gtk/0025-quartz-Add-a-dummy-NSView-serving-as-layer-view.patch',
-				'patches/gtk/0026-gtk-port-overlay-scrollbars-to-native-CALayers.patch',
-				'patches/gtk/0027-Refrain-from-starting-fading-out-while-a-gesture-is-.patch',
-				'patches/gtk/0028-gtk-don-t-show-the-olverlay-scrollbars-if-only-the-s.patch',
-				'patches/gtk/0029-Reclamp-unclamped-adjustments-after-resize.patch',
-				'patches/gtk/0030-gtk-fix-size_request-of-scrolled-window.patch',
-				'patches/gtk/0031-Hackish-fix-for-bug-8493-Min-size-of-GtkScrolledWind.patch',
-				'patches/gtk/0032-Add-momentum_phase-to-GdkEventScroll.patch',
-				'patches/gtk/0033-Never-intervene-in-the-event-stream-for-legacy-mice.patch',
-				'patches/gtk/0034-Do-not-start-overshooting-for-legacy-mouse-scroll-ev.patch',
-				'patches/gtk/0035-gtk-remove-the-overlay-scrollbar-grab-on-unrealize.patch',
-				'patches/gtk/0036-gtk-add-GtkScrolledWindow-API-to-disable-overshoot-p.patch',
-				'patches/gtk/0037-quartz-return-events-on-embedded-foreign-NSViews-bac.patch',
-				'patches/gtk/0038-quartz-don-t-forward-events-to-the-toplevel-nswindow.patch',
-				'patches/gtk/0039-gdk-add-a-move-native-children-signal-to-GdkWindow.patch',
-				'patches/gtk/0040-gtk-add-new-widget-GtkNSView-which-alows-to-embed-an.patch',
-				'patches/gtk/0041-tests-add-a-notebook-to-testnsview.c.patch',
-				'patches/gtk/0042-gtk-connect-GtkNSView-to-move-native-children-and-re.patch',
-				'patches/gtk/0043-tests-add-a-scrolled-window-test-widget-to-testnsvie.patch',
-				'patches/gtk/0044-gtknsview-clip-drawRect-to-a-parent-GtkViewport-s-wi.patch',
-				'patches/gtk/0045-gtk-clip-NSViews-to-the-scrolled-window-s-overshoot_.patch',
-				'patches/gtk/0046-gtk-implement-clipping-to-multiple-parent-viewports-.patch',
-				'patches/gtk/0047-gtk-first-attempt-to-also-clip-NSWindow-s-field-edit.patch',
-				'patches/gtk/0048-gtk-also-clip-the-NSView-s-subviews.patch',
-				'patches/gtk/0049-nsview-also-swizzle-DidAddSubview-and-clip-all-subvi.patch',
-				'patches/gtk/0050-nsview-clip-text-field-cursor-drawing.patch',
-				'patches/gtk/0051-nsview-factor-out-almost-all-code-from-the-overridde.patch',
-				'patches/gtk/0052-nsview-also-focus-the-GtkNSView-if-a-focussable-subv.patch',
-				'patches/gtk/0053-gtk-add-an-overlay-policy-API-to-GtkScrolledWindow.patch',
-				'patches/gtk/0054-quartz-add-gdk_screen_-and-gdk_window_get_scale_fact.patch',
-				'patches/gtk/0055-gtk-add-gtk_widget_get_scale_factor.patch',
-				'patches/gtk/0056-iconfactory-Add-_scaled-variants.patch',
-				'patches/gtk/0057-widget-Add-_scaled-variants-for-icon-rendering.patch',
-				'patches/gtk/0058-icontheme-Add-support-for-high-resolution-icons.patch',
-				'patches/gtk/0059-iconfactory-Add-scale-info-to-GtkIconSource.patch',
-				'patches/gtk/0060-iconfactory-Add-gtk_cairo_set_source_icon_set.patch',
-				'patches/gtk/0061-image-Use-scaled-icons-on-windows-with-a-scaling-fac.patch',
-				'patches/gtk/0062-cellrendererpixbuf-Use-scaled-icons-on-windows-with-.patch',
-				'patches/gtk/0063-entry-Use-scaled-icons-on-windows-with-a-scale-facto.patch',
-				'patches/gtk/0064-gdk-Lookup-double-scaled-variants-on-pixbufs.patch',
-				'patches/gtk/0065-Make-usual-calls-to-get-a-GdkPixbuf-attach-a-2x-vari.patch',
-				'patches/gtk/0066-cellrendererpixbuf-let-2x-variants-go-through-pixel-.patch',
-				'patches/gtk/0067-quartz-Make-event-loop-deal-with-recursive-poll-invo.patch',
-				'patches/gtk/0068-nsview-implement-a-few-text-view-command-accelerator.patch',
-				'patches/gtk/0069-menu-scrolling.patch',
-				'patches/gtk/0070-tooltips-focus.patch',
-				'patches/gtk/0071-light-and-dark-overlay-scrollbars.patch',
-				'patches/gtk/0072-let-global-keyboard-shortcuts-pass-through.patch',
-				'patches/gtk/0073-disable-combobox-scrolling.patch',
-				'patches/gtk/0074-fix-NULL-pointer-in-clipboard.patch',
-				'patches/gtk/0075-filechooserwidget-location-entry-activation.patch',
-				'patches/gtk/0076-iconfactory-treat-gt-1-0-icons-as-2-0.patch',
+				Patch('patches/gtk/0001-Add-invariant-that-a-child-is-unmapped-if-parent-is-.patch', options = default_patch_options),
+				Patch('patches/gtk/0002-Maintain-map-unmap-invariants-in-GtkRecentChooserDia.patch', options = default_patch_options),
+				Patch('patches/gtk/0003-GtkPlug-preserve-map-unmap-invariants.patch', options = default_patch_options),
+				Patch('patches/gtk/0004-Add-gdk_screen_get_monitor_workarea-and-use-it-all-o.patch', options = default_patch_options),
+				Patch('patches/gtk/0005-gtk-don-t-scroll-combo-box-menus-if-less-than-3-item.patch', options = default_patch_options),
+				Patch('patches/gtk/0006-gtk-paint-only-the-exposed-region-in-gdk_window_expo.patch', options = default_patch_options),
+				Patch('patches/gtk/0007-Implement-gtk-enable-overlay-scrollbars-GtkSetting.patch', options = default_patch_options),
+				Patch('patches/gtk/0008-Smooth-scrolling.patch', options = default_patch_options),
+				Patch('patches/gtk/0009-gtk-Add-a-way-to-do-event-capture.patch', options = default_patch_options),
+				Patch('patches/gtk/0010-gtk-don-t-let-insensitive-children-eat-scroll-events.patch', options = default_patch_options),
+				Patch('patches/gtk/0011-scrolledwindow-Kinetic-scrolling-support.patch', options = default_patch_options),
+				Patch('patches/gtk/0012-gtk-paint-to-the-right-windows-in-gtk_scrolled_windo.patch', options = default_patch_options),
+				Patch('patches/gtk/0013-GtkScrolledWindow-add-overlay-scrollbars.patch', options = default_patch_options),
+				Patch('patches/gtk/0014-gtk-add-event-handling-to-GtkScrolledWindow-s-overla.patch', options = default_patch_options),
+				Patch('patches/gtk/0015-Use-gtk-enable-overlay-scrollbars-in-GtkScrolledWind.patch', options = default_patch_options),
+				Patch('patches/gtk/0016-gtk-correctly-handle-toggling-of-the-scrollbar-visib.patch', options = default_patch_options),
+				Patch('patches/gtk/0017-gtk-handle-gtk-primary-button-warps-slider-for-the-o.patch', options = default_patch_options),
+				Patch('patches/gtk/0018-Introduce-phase-field-in-GdkEventScroll.patch', options = default_patch_options),
+				Patch('patches/gtk/0019-Add-hack-to-lock-flow-of-scroll-events-to-window-whe.patch', options = default_patch_options),
+				Patch('patches/gtk/0020-Introduce-a-background-window.patch', options = default_patch_options),
+				Patch('patches/gtk/0021-Make-scrolled-window-work-well-with-Mac-touchpad.patch', options = default_patch_options),
+				Patch('patches/gtk/0022-Use-start-end-phase-in-event-handling.patch', options = default_patch_options),
+				Patch('patches/gtk/0023-Improve-overshooting-behavior.patch', options = default_patch_options),
+				Patch('patches/gtk/0024-Cancel-out-smaller-delta-component.patch', options = default_patch_options),
+				Patch('patches/gtk/0025-quartz-Add-a-dummy-NSView-serving-as-layer-view.patch', options = default_patch_options),
+				Patch('patches/gtk/0026-gtk-port-overlay-scrollbars-to-native-CALayers.patch', options = default_patch_options),
+				Patch('patches/gtk/0027-Refrain-from-starting-fading-out-while-a-gesture-is-.patch', options = default_patch_options),
+				Patch('patches/gtk/0028-gtk-don-t-show-the-olverlay-scrollbars-if-only-the-s.patch', options = default_patch_options),
+				Patch('patches/gtk/0029-Reclamp-unclamped-adjustments-after-resize.patch', options = default_patch_options),
+				Patch('patches/gtk/0030-gtk-fix-size_request-of-scrolled-window.patch', options = default_patch_options),
+				Patch('patches/gtk/0031-Hackish-fix-for-bug-8493-Min-size-of-GtkScrolledWind.patch', options = default_patch_options),
+				Patch('patches/gtk/0032-Add-momentum_phase-to-GdkEventScroll.patch', options = default_patch_options),
+				Patch('patches/gtk/0033-Never-intervene-in-the-event-stream-for-legacy-mice.patch', options = default_patch_options),
+				Patch('patches/gtk/0034-Do-not-start-overshooting-for-legacy-mouse-scroll-ev.patch', options = default_patch_options),
+				Patch('patches/gtk/0035-gtk-remove-the-overlay-scrollbar-grab-on-unrealize.patch', options = default_patch_options),
+				Patch('patches/gtk/0036-gtk-add-GtkScrolledWindow-API-to-disable-overshoot-p.patch', options = default_patch_options),
+				Patch('patches/gtk/0037-quartz-return-events-on-embedded-foreign-NSViews-bac.patch', options = default_patch_options),
+				Patch('patches/gtk/0038-quartz-don-t-forward-events-to-the-toplevel-nswindow.patch', options = default_patch_options),
+				Patch('patches/gtk/0039-gdk-add-a-move-native-children-signal-to-GdkWindow.patch', options = default_patch_options),
+				Patch('patches/gtk/0040-gtk-add-new-widget-GtkNSView-which-alows-to-embed-an.patch', options = default_patch_options),
+				Patch('patches/gtk/0041-tests-add-a-notebook-to-testnsview.c.patch', options = default_patch_options),
+				Patch('patches/gtk/0042-gtk-connect-GtkNSView-to-move-native-children-and-re.patch', options = default_patch_options),
+				Patch('patches/gtk/0043-tests-add-a-scrolled-window-test-widget-to-testnsvie.patch', options = default_patch_options),
+				Patch('patches/gtk/0044-gtknsview-clip-drawRect-to-a-parent-GtkViewport-s-wi.patch', options = default_patch_options),
+				Patch('patches/gtk/0045-gtk-clip-NSViews-to-the-scrolled-window-s-overshoot_.patch', options = default_patch_options),
+				Patch('patches/gtk/0046-gtk-implement-clipping-to-multiple-parent-viewports-.patch', options = default_patch_options),
+				Patch('patches/gtk/0047-gtk-first-attempt-to-also-clip-NSWindow-s-field-edit.patch', options = default_patch_options),
+				Patch('patches/gtk/0048-gtk-also-clip-the-NSView-s-subviews.patch', options = default_patch_options),
+				Patch('patches/gtk/0049-nsview-also-swizzle-DidAddSubview-and-clip-all-subvi.patch', options = default_patch_options),
+				Patch('patches/gtk/0050-nsview-clip-text-field-cursor-drawing.patch', options = default_patch_options),
+				Patch('patches/gtk/0051-nsview-factor-out-almost-all-code-from-the-overridde.patch', options = default_patch_options),
+				Patch('patches/gtk/0052-nsview-also-focus-the-GtkNSView-if-a-focussable-subv.patch', options = default_patch_options),
+				Patch('patches/gtk/0053-gtk-add-an-overlay-policy-API-to-GtkScrolledWindow.patch', options = default_patch_options),
+				Patch('patches/gtk/0054-quartz-add-gdk_screen_-and-gdk_window_get_scale_fact.patch', options = default_patch_options),
+				Patch('patches/gtk/0055-gtk-add-gtk_widget_get_scale_factor.patch', options = default_patch_options),
+				Patch('patches/gtk/0056-iconfactory-Add-_scaled-variants.patch', options = default_patch_options),
+				Patch('patches/gtk/0057-widget-Add-_scaled-variants-for-icon-rendering.patch', options = default_patch_options),
+				Patch('patches/gtk/0058-icontheme-Add-support-for-high-resolution-icons.patch', options = default_patch_options),
+				Patch('patches/gtk/0059-iconfactory-Add-scale-info-to-GtkIconSource.patch', options = default_patch_options),
+				Patch('patches/gtk/0060-iconfactory-Add-gtk_cairo_set_source_icon_set.patch', options = default_patch_options),
+				Patch('patches/gtk/0061-image-Use-scaled-icons-on-windows-with-a-scaling-fac.patch', options = default_patch_options),
+				Patch('patches/gtk/0062-cellrendererpixbuf-Use-scaled-icons-on-windows-with-.patch', options = default_patch_options),
+				Patch('patches/gtk/0063-entry-Use-scaled-icons-on-windows-with-a-scale-facto.patch', options = default_patch_options),
+				Patch('patches/gtk/0064-gdk-Lookup-double-scaled-variants-on-pixbufs.patch', options = default_patch_options),
+				Patch('patches/gtk/0065-Make-usual-calls-to-get-a-GdkPixbuf-attach-a-2x-vari.patch', options = default_patch_options),
+				Patch('patches/gtk/0066-cellrendererpixbuf-let-2x-variants-go-through-pixel-.patch', options = default_patch_options),
+				Patch('patches/gtk/0067-quartz-Make-event-loop-deal-with-recursive-poll-invo.patch', options = default_patch_options),
+				Patch('patches/gtk/0068-nsview-implement-a-few-text-view-command-accelerator.patch', options = default_patch_options),
+				Patch('patches/gtk/0069-menu-scrolling.patch', options = default_patch_options),
+				Patch('patches/gtk/0070-tooltips-focus.patch', options = default_patch_options),
+				Patch('patches/gtk/0071-light-and-dark-overlay-scrollbars.patch', options = default_patch_options),
+				Patch('patches/gtk/0072-let-global-keyboard-shortcuts-pass-through.patch', options = default_patch_options),
+				Patch('patches/gtk/0073-disable-combobox-scrolling.patch', options = default_patch_options),
+				Patch('patches/gtk/0074-fix-NULL-pointer-in-clipboard.patch', options = default_patch_options),
+				Patch('patches/gtk/0075-filechooserwidget-location-entry-activation.patch', options = default_patch_options),
+				Patch('patches/gtk/0076-iconfactory-treat-gt-1-0-icons-as-2-0.patch', options = default_patch_options),
 
 				# Bug 702841 - GdkQuartz does not distinguish Eisu, Kana and Space keys on Japanese keyrboard
 				# https://bugzilla.gnome.org/show_bug.cgi?id=702841
-				'patches/gtk/bgo702841-fix-kana-eisu-keys.patch',
+				Patch('patches/gtk/bgo702841-fix-kana-eisu-keys.patch', options = default_patch_options),
 
 				# make new modifier behviour opt-in, so as not to break old versions of MonoDevelop
-				'patches/gdk-quartz-set-fix-modifiers-hack-v3.patch',
+				Patch('patches/gdk-quartz-set-fix-modifiers-hack-v3.patch', options = default_patch_options),
 
 				# attempt to work around 2158 - [GTK] crash triggering context menu
 				# also prints some warnings that may help to debug the real issue
 				# https://bugzilla.xamarin.com/attachment.cgi?id=1644
-				'patches/gtk/bxc2158_workaround_crash_triggering_context_menu.patch',
+				Patch('patches/gtk/bxc2158_workaround_crash_triggering_context_menu.patch', options = default_patch_options),
 
 				# Zoom, rotate, swipe events
-				'patches/gtk-gestures.patch',
+				Patch('patches/gtk-gestures.patch', options = default_patch_options),
 
 				# Fix gtk_window_begin_move_drag on Quartz
-				'patches/gtk-quartz-move-drag.patch',
+				Patch('patches/gtk-quartz-move-drag.patch', options = default_patch_options),
 
 				# Bug 3457 - [GTK] Support more standard keyboard shortcuts in dialogs
 				# https://bugzilla.xamarin.com/attachment.cgi?id=2240
-				'patches/gtk/bxc3457_more_standard_keyboard_shortcuts.patch',
+				Patch('patches/gtk/bxc3457_more_standard_keyboard_shortcuts.patch', options = default_patch_options),
 
 				# Bug  10256 - Mac window manipulation tools get confused by Xamarin Studio
 				# https://bugzilla.xamarin.com/attachment.cgi?id=3465
-				'patches/gtk/bxc_10256_window_tools_get_confused.diff',
+				Patch('patches/gtk/bxc_10256_window_tools_get_confused.diff', options = default_patch_options),
 
-#                                'patches/gtk/gdk-pixmap-get-cgimage-2.patch',
+#                                Patch('patches/gtk/gdk-pixmap-get-cgimage-2.patch', options = default_patch_options),
 
 				# https://bugzilla.xamarin.com/show_bug.cgi?id=18157
-				'patches/gtk/gtk-check-grab_toplevel-is-destroyed.patch',
+				Patch('patches/gtk/gtk-check-grab_toplevel-is-destroyed.patch', options = default_patch_options),
 
 				# https://bugzilla.xamarin.com/show_bug.cgi?id=18241
 				# https://bugzilla.xamarin.com/show_bug.cgi?id=17631
 				# https://bugzilla.xamarin.com/show_bug.cgi?id=17692
-				'patches/gtk/gtk-imquartz-defer-signals-in-output_result.patch',
+				Patch('patches/gtk/gtk-imquartz-defer-signals-in-output_result.patch', options = default_patch_options),
 
 				# https://bugzilla.xamarin.com/show_bug.cgi?id=17401
-				'patches/gtk/gtknsview-defer-map-and-lock-in-clipping.patch',
-				'patches/gtk/gtknsview-timeout-fix.patch',
+				Patch('patches/gtk/gtknsview-defer-map-and-lock-in-clipping.patch', options = default_patch_options),
+				Patch('patches/gtk/gtknsview-timeout-fix.patch', options = default_patch_options),
 
-                                'patches/gtk/nsview-embedding.patch',
+                                Patch('patches/gtk/nsview-embedding.patch', options = default_patch_options),
 
-                                'patches/gtk/enable-swizzle-property.patch',
+                                Patch('patches/gtk/enable-swizzle-property.patch', options = default_patch_options),
 
 				# https://bugzilla.xamarin.com/show_bug.cgi?id=12618
-				'patches/gtk/disable-eye-dropper.patch',
+				Patch('patches/gtk/disable-eye-dropper.patch', options = default_patch_options),
 
 				# https://bugzilla.xamarin.com/show_bug.cgi?id=13100
-				'patches/gtk/flip-command-mask-between-mod1-and-mod2.patch',
-				'patches/gtk/nsview-embedding-fix-keyboard-routing.patch',
-				'patches/gtk/nsview-check-for-superview.patch',
+				Patch('patches/gtk/flip-command-mask-between-mod1-and-mod2.patch', options = default_patch_options),
+				Patch('patches/gtk/nsview-embedding-fix-keyboard-routing.patch', options = default_patch_options),
+				Patch('patches/gtk/nsview-check-for-superview.patch', options = default_patch_options),
 
-				'patches/gtk/gtknsview-forward-cmdz-to-textview-undo-manager.patch',
+				Patch('patches/gtk/gtknsview-forward-cmdz-to-textview-undo-manager.patch', options = default_patch_options),
 
 				# https://bugzilla.xamarin.com/show_bug.cgi?id=20732
-				'patches/gtk/embedded-nstextview-has-focus.patch',
-				'patches/gtk/remove-demos-from-build.patch',
+				Patch('patches/gtk/embedded-nstextview-has-focus.patch', options = default_patch_options),
+				Patch('patches/gtk/remove-demos-from-build.patch', options = default_patch_options),
 
 				# This fixes an issue in where in some situations the user needed
 				# to click a native text entry twice in order to be able to focus it.
-				'patches/gtk/gtknsview-only-unset-first-responder-if-it-is-our-view.patch',
+				Patch('patches/gtk/gtknsview-only-unset-first-responder-if-it-is-our-view.patch', options = default_patch_options),
 
 				# For the test framework to be able to traverse down the NSView hierarchy
-				'patches/gtk/gtknsview-getter.patch',
+				Patch('patches/gtk/gtknsview-getter.patch', options = default_patch_options),
 
 				# This is hacky, but the designer needs a way to handle drag events
 				# from Xamarin.Mac and GTK is eating them. If a better solution is found
 				# we should remove this.
 				# https://bugzilla.xamarin.com/show_bug.cgi?id=29301
-				'patches/gtk/gtk-yield-mouse-events-to-cocoa.patch',
+				Patch('patches/gtk/gtk-yield-mouse-events-to-cocoa.patch', options = default_patch_options),
 
 				# https://bugzilla.xamarin.com/show_bug.cgi?id=29301#c3
-				'patches/gtk/gtknsview-fix-invalid-casts.patch',
+				Patch('patches/gtk/gtknsview-fix-invalid-casts.patch', options = default_patch_options),
 
 				# https://bugzilla.xamarin.com/show_bug.cgi?id=29001
-				'patches/gtk/quartz-call-undo-redo-on-cmdz.patch'
+				Patch('patches/gtk/quartz-call-undo-redo-on-cmdz.patch', options = default_patch_options),
 			])
 
 		self.make = "GDK_PIXBUF_MODULEDIR=%{staged_prefix}/lib/gdk-pixbuf-2.0/2.10.0/loaders GDK_PIXBUF_MODULE_FILE=%{staged_prefix}/lib/gdk-pixbuf-2.0/2.10.0/loaders.cache " + self.make

--- a/packages/gtk+.py
+++ b/packages/gtk+.py
@@ -174,12 +174,6 @@ class GtkPackage (GnomeGitPackage):
 
 		self.make = "GDK_PIXBUF_MODULEDIR=%{staged_prefix}/lib/gdk-pixbuf-2.0/2.10.0/loaders GDK_PIXBUF_MODULE_FILE=%{staged_prefix}/lib/gdk-pixbuf-2.0/2.10.0/loaders.cache " + self.make
 
-	def prep (self):
-		Package.prep (self)
-		if Package.profile.name == 'darwin':
-			for p in range (2, len (self.local_sources)):
-				self.sh ('patch -p1 --ignore-whitespace < "%{local_sources[' + str (p) + ']}"')
-
 	def install(self):
 		Package.install(self)
 		if Package.profile.name == 'darwin':

--- a/packages/gtk-mac-integration.py
+++ b/packages/gtk-mac-integration.py
@@ -15,10 +15,4 @@ class Gtkmacintegration (GnomeXzPackage):
 				Patch('http://git.gnome.org/browse/gtk-mac-integration/patch/?id=19cf4ee74821aa5d6d70d0a069178fa5a684ff7f', '-p1'),
 			])
 
-	def prep (self):
-		Package.prep (self)
-		if Package.profile.name == 'darwin':
-			for p in self.patches:
-				p.run(self)
-
 Gtkmacintegration()

--- a/packages/gtk-mac-integration.py
+++ b/packages/gtk-mac-integration.py
@@ -8,16 +8,17 @@ class Gtkmacintegration (GnomeXzPackage):
 			'--prefix="%{prefix}"'
 		])
 
-		self.sources.extend([
-			# fix Alt/Mod1 key behaviour on OS X - required
-			# for key accelerators using the alt/option key on OSX 
-			'http://git.gnome.org/browse/gtk-mac-integration/patch/?id=19cf4ee74821aa5d6d70d0a069178fa5a684ff7f'
-		])
+		if Package.profile.name == 'darwin':
+			self.sources.extend([
+				# fix Alt/Mod1 key behaviour on OS X - required
+				# for key accelerators using the alt/option key on OSX 
+				Patch('http://git.gnome.org/browse/gtk-mac-integration/patch/?id=19cf4ee74821aa5d6d70d0a069178fa5a684ff7f', '-p1'),
+			])
 
 	def prep (self):
 		Package.prep (self)
 		if Package.profile.name == 'darwin':
-			for p in range (1, len (self.local_sources)):
-				self.sh ('patch -p1 < "%{local_sources[' + str (p) + ']}"')
+			for p in self.patches:
+				p.run(self)
 
 Gtkmacintegration()

--- a/packages/libogg.py
+++ b/packages/libogg.py
@@ -2,16 +2,17 @@ class LiboggPackage (XiphPackage):
         def __init__ (self):
                 XiphPackage.__init__ (self,
                         project  = 'ogg',
-			name = 'libogg',
+                        name = 'libogg',
                         version = '1.3.0')
 
                 self.configure = 'autoreconf -fi && ./configure --prefix="%{prefix}"'
 
 		# reduce optimization from -O4 to -O3 to allow compilation on Xcode 4.2.1
-                self.sources.append ('patches/libogg-opt.patch')
+                self.sources.append (Patch('patches/libogg-opt.patch', '-p1'))
 
         def prep (self):
                 Package.prep (self)
-                self.sh ('patch -p1 < "%{local_sources[1]}"')
+                for patch in self.patches:
+                        patch.run(self)
 
 LiboggPackage ()

--- a/packages/libogg.py
+++ b/packages/libogg.py
@@ -10,9 +10,4 @@ class LiboggPackage (XiphPackage):
 		# reduce optimization from -O4 to -O3 to allow compilation on Xcode 4.2.1
                 self.sources.append (Patch('patches/libogg-opt.patch', '-p1'))
 
-        def prep (self):
-                Package.prep (self)
-                for patch in self.patches:
-                        patch.run(self)
-
 LiboggPackage ()

--- a/packages/libtiff.py
+++ b/packages/libtiff.py
@@ -11,13 +11,13 @@ class LibTiffPackage (Package):
 			self.sources.extend ([
 				# Fix Snow Leopard build
 				# http://jira.freeswitch.org/secure/attachment/17487/tiff-4.0.2-macosx-2.patch
-				'patches/tiff-4.0.2-macosx-2.patch'
+				Patch('patches/tiff-4.0.2-macosx-2.patch', '-p1'),
 			])
 
 	def prep (self):
 		Package.prep (self)
 		if Package.profile.name == 'darwin':
-			for p in range (1, len (self.local_sources)):
-				self.sh ('patch -p1 < "%{local_sources[' + str (p) + ']}"')
+			for p in self.patches:
+				p.run (self)
 
 LibTiffPackage ()

--- a/packages/libtiff.py
+++ b/packages/libtiff.py
@@ -14,10 +14,4 @@ class LibTiffPackage (Package):
 				Patch('patches/tiff-4.0.2-macosx-2.patch', '-p1'),
 			])
 
-	def prep (self):
-		Package.prep (self)
-		if Package.profile.name == 'darwin':
-			for p in self.patches:
-				p.run (self)
-
 LibTiffPackage ()

--- a/packages/libvorbis.py
+++ b/packages/libvorbis.py
@@ -11,9 +11,4 @@ class LibvorbisPackage (XiphPackage):
                         Patch('patches/libvorbis-opt.patch', '-p1')
                 ])
 
-        def prep (self):
-                Package.prep (self)
-                for patch in self.patches:
-                        patch.run(self)
-
 LibvorbisPackage ()

--- a/packages/libvorbis.py
+++ b/packages/libvorbis.py
@@ -2,15 +2,18 @@ class LibvorbisPackage (XiphPackage):
         def __init__ (self):
                 XiphPackage.__init__ (self,
                         project  = 'vorbis',
-			name = 'libvorbis',
+                        name = 'libvorbis',
                         version = '1.3.2')
-		self.configure = './configure --prefix="%{prefix}"'
+                self.configure = './configure --prefix="%{prefix}"'
 
-		# reduce optimization from -O4 to -O3 to allow compilation on Xcode 4.2.1
-		self.sources.append ('patches/libvorbis-opt.patch')
+                # reduce optimization from -O4 to -O3 to allow compilation on Xcode 4.2.1
+                self.sources.append ([
+                        Patch('patches/libvorbis-opt.patch', '-p1')
+                ])
 
         def prep (self):
                 Package.prep (self)
-                self.sh ('patch -p1 < "%{local_sources[1]}"')
+                for patch in self.patches:
+                        patch.run(self)
 
 LibvorbisPackage ()

--- a/packages/libxml2.py
+++ b/packages/libxml2.py
@@ -12,8 +12,8 @@ class LibXmlPackage (Package):
 	def prep (self):
 		Package.prep (self)
 		if Package.profile.name == 'darwin':
-			for p in range (1, len (self.local_sources)):
-				self.sh ('patch -p1 < "%{local_sources[' + str (p) + ']}"')
+			for p in self.patches:
+				p.run(self)
 
 LibXmlPackage ()
 

--- a/packages/libxml2.py
+++ b/packages/libxml2.py
@@ -9,11 +9,5 @@ class LibXmlPackage (Package):
 			]
 		)
 
-	def prep (self):
-		Package.prep (self)
-		if Package.profile.name == 'darwin':
-			for p in self.patches:
-				p.run(self)
-
 LibXmlPackage ()
 

--- a/packages/mono-2-10.py
+++ b/packages/mono-2-10.py
@@ -23,7 +23,7 @@ class MonoTwoTenPackage(Package):
 
 			self.sources.extend ([
 					# Fixes up pkg-config usage on the Mac
-					'patches/mcs-pkgconfig.patch'
+					Patch('patches/mcs-pkgconfig.patch', '-p1')
 					])
 
 		self.configure = './autogen.sh'

--- a/packages/mono-2-10.py
+++ b/packages/mono-2-10.py
@@ -28,11 +28,4 @@ class MonoTwoTenPackage(Package):
 
 		self.configure = './autogen.sh'
 
-	def prep (self):
-		Package.prep (self)
-		if Package.profile.name == 'darwin':
-			for p in range (1, len (self.sources)):
-				self.sh ('patch -p1 < "%{sources[' + str (p) + ']}"')
-
-
 MonoTwoTenPackage()

--- a/packages/mono-martin.py
+++ b/packages/mono-martin.py
@@ -22,7 +22,7 @@ class MonoMasterPackage(Package):
 
 			self.sources.extend ([
 					# Fixes up pkg-config usage on the Mac
-					'patches/mcs-pkgconfig.patch'
+					Patch('patches/mcs-pkgconfig.patch', '-p1')
 					])
 
 		self.configure = 'CFLAGS=-O2 ./autogen.sh'
@@ -30,7 +30,7 @@ class MonoMasterPackage(Package):
 	def prep (self):
 		Package.prep (self)
 		if Package.profile.name == 'darwin':
-			for p in range (1, len (self.local_sources)):
-				self.sh ('patch -p1 < "%{local_sources[' + str (p) + ']}"')
+			for p in self.patches:
+				p.run(self)
 
 MonoMasterPackage()

--- a/packages/mono-martin.py
+++ b/packages/mono-martin.py
@@ -27,10 +27,4 @@ class MonoMasterPackage(Package):
 
 		self.configure = 'CFLAGS=-O2 ./autogen.sh'
 
-	def prep (self):
-		Package.prep (self)
-		if Package.profile.name == 'darwin':
-			for p in self.patches:
-				p.run(self)
-
 MonoMasterPackage()

--- a/packages/mono-master.py
+++ b/packages/mono-master.py
@@ -27,7 +27,7 @@ class MonoMasterPackage(Package):
 
 			self.sources.extend ([
 					# Fixes up pkg-config usage on the Mac
-					'patches/mcs-pkgconfig.patch'
+					Patch('patches/mcs-pkgconfig.patch', '-p1'),
 					])
 		else:
 			self.configure_flags.extend([
@@ -40,8 +40,8 @@ class MonoMasterPackage(Package):
 
 	def prep (self):
 		Package.prep (self)
-		for p in range (1, len (self.local_sources)):
-			self.sh ('patch -p1 < "%{local_sources[' + str (p) + ']}"')
+		for p in self.patches:
+			p.run(self)
 
 	def arch_build (self, arch):	
 		if arch == 'darwin-64': #64-bit build pass

--- a/packages/mono-master.py
+++ b/packages/mono-master.py
@@ -38,11 +38,6 @@ class MonoMasterPackage(Package):
 
 		self.configure = './autogen.sh --prefix="%{package_prefix}"'
 
-	def prep (self):
-		Package.prep (self)
-		for p in self.patches:
-			p.run(self)
-
 	def arch_build (self, arch):	
 		if arch == 'darwin-64': #64-bit build pass
 			self.local_gcc_flags = ['-m64']

--- a/packages/mono-upnp.py
+++ b/packages/mono-upnp.py
@@ -10,7 +10,7 @@ class MonoUpnpPackage (GitHubTarballPackage):
 
 		self.sources.extend ([
 			# allow building without NUnit installed
-			'patches/mono-upnp_add_disable_tests_flag.patch'
+			Patch('patches/mono-upnp_add_disable_tests_flag.patch', '-p1')
 		])
 
 	def prep (self):

--- a/packages/mono-upnp.py
+++ b/packages/mono-upnp.py
@@ -13,9 +13,4 @@ class MonoUpnpPackage (GitHubTarballPackage):
 			Patch('patches/mono-upnp_add_disable_tests_flag.patch', '-p1')
 		])
 
-	def prep (self):
-		GitHubTarballPackage.prep (self)
-		for p in range (1, len (self.sources)):
-			self.sh ('patch -p1 < "%{sources[' + str (p) + ']}"')
-
 MonoUpnpPackage ()

--- a/packages/mono.py
+++ b/packages/mono.py
@@ -23,10 +23,6 @@ class MonoPackage (Package):
 		# Mono (in libgc) likes to fail to build randomly
 		self.make = 'for i in 1 2 3 4 5 6 7 8 9 10; do make && break; done'
 
-	def prep (self):
-		Package.prep (self)
-		self.sh ('patch -p1 < "%{sources[2]}"')
-
 	def install (self):
 		Package.install (self)
 		if Package.profile.name == 'darwin':

--- a/packages/mono.py
+++ b/packages/mono.py
@@ -4,7 +4,7 @@ class MonoPackage (Package):
 			sources = [
 				'http://download.mono-project.com/sources/%{name}/%{name}-%{version}.tar.bz2',
 				'patches/mono-gtk-sharp-profiler.patch',
-				'patches/xbuild-bug4365.patch'
+				Patch('patches/xbuild-bug4365.patch', options = '-p1')
 			],
 			configure_flags = [
 				'--with-jit=yes',

--- a/packages/murrine.py
+++ b/packages/murrine.py
@@ -9,7 +9,4 @@ class MurrinePackage (GnomeXzPackage):
 		# FIXME: this may need porting
 		# self.sources.append ('patches/murrine-osx.patch')
 
-	def prep (self):
-		Package.prep (self)
-
 MurrinePackage ()

--- a/packages/pango.py
+++ b/packages/pango.py
@@ -9,32 +9,31 @@ class PangoPackage (GnomeXzPackage):
 			]
 		)
 
-		self.sources.extend ([
-			# 1
-			# Bug 321419 - Allow environment var substitution in Pango config
-			# https://bugzilla.gnome.org/show_bug.cgi?id=321419
-			'patches/pango-relative-config-file.patch',
-
-			# BXC 10257 - Characters outside the Basic Multilingual Plane don't render correctly
-			# https://bugzilla.xamarin.com/show_bug.cgi?id=10257
-			'patches/pango-coretext-astral-plane-1.patch',
-			'patches/pango-coretext-astral-plane-2.patch',
-
-                        # Bug 15787 - Caret position is wrong when there are ligatures
-                        # https://bugzilla.xamarin.com/show_bug.cgi?id=15787
-                        'patches/pango-disable-ligatures.patch',
-
-                        # https://bugzilla.xamarin.com/show_bug.cgi?id=22199
-                        'patches/pango-fix-ct_font_descriptor_get_weight-crasher.patch',
-
-                        # https://bugzilla.gnome.org/show_bug.cgi?id=734372
-                        'patches/pango-coretext-condensed-trait.patch'
-		])
+		default_patch_options = '-p1'
 
 	def prep (self):
 		GnomePackage.prep (self)
 		if Package.profile.name == 'darwin':
-			for p in range (1, len (self.local_sources)):
-				self.sh ('patch -p1 < "%{local_sources[' + str (p) + ']}"')
+			self.sources.extend ([
+				# 1
+				# Bug 321419 - Allow environment var substitution in Pango config
+				# https://bugzilla.gnome.org/show_bug.cgi?id=321419
+				Patch('patches/pango-relative-config-file.patch', options = default_patch_options),
+
+				# BXC 10257 - Characters outside the Basic Multilingual Plane don't render correctly
+				# https://bugzilla.xamarin.com/show_bug.cgi?id=10257
+				Patch('patches/pango-coretext-astral-plane-1.patch', options = default_patch_options),
+				Patch('patches/pango-coretext-astral-plane-2.patch', options = default_patch_options),
+
+				# Bug 15787 - Caret position is wrong when there are ligatures
+				# https://bugzilla.xamarin.com/show_bug.cgi?id=15787
+				Patch('patches/pango-disable-ligatures.patch', options = default_patch_options),
+
+				# https://bugzilla.xamarin.com/show_bug.cgi?id=22199
+				Patch('patches/pango-fix-ct_font_descriptor_get_weight-crasher.patch', options = default_patch_options),
+
+				# https://bugzilla.gnome.org/show_bug.cgi?id=734372
+				Patch('patches/pango-coretext-condensed-trait.patch', options = default_patch_options), 
+			])
 
 PangoPackage ()

--- a/packages/pango.py
+++ b/packages/pango.py
@@ -11,8 +11,6 @@ class PangoPackage (GnomeXzPackage):
 
 		default_patch_options = '-p1'
 
-	def prep (self):
-		GnomePackage.prep (self)
 		if Package.profile.name == 'darwin':
 			self.sources.extend ([
 				# 1

--- a/packages/webkit.py
+++ b/packages/webkit.py
@@ -21,7 +21,7 @@ class WebkitPackage (Package):
 			self.sources.extend ([
 				# disable xrender when building with quartz, see
 				# https://trac.macports.org/attachment/ticket/34086/xrender-check.patch
-				'https://trac.macports.org/raw-attachment/ticket/34086/xrender-check.patch'
+				Patch('https://trac.macports.org/raw-attachment/ticket/34086/xrender-check.patch', options = '-p0')
 			])
 
 	def prep (self):

--- a/packages/webkit.py
+++ b/packages/webkit.py
@@ -24,10 +24,5 @@ class WebkitPackage (Package):
 				Patch('https://trac.macports.org/raw-attachment/ticket/34086/xrender-check.patch', options = '-p0')
 			])
 
-	def prep (self):
-		Package.prep (self)
-		if Package.profile.name == 'darwin':
-			for p in range (1, len (self.sources)):
-				self.sh ('patch -p0 < "%{local_sources[' + str (p) + ']}"')
 
 WebkitPackage()


### PR DESCRIPTION
Make patching a separate step, track patches as a seperate class and create a seperate list of them to apply after fetching to avoid array indexing errors.
