### PR TITLE
[package] print the name of the package earlier

### DIFF
--- a/bockbuild/package.py
+++ b/bockbuild/package.py
@@ -288,8 +288,6 @@ class Package:
 				warn ('Version in configure.ac is %s, package declares %s' % (found_version, package_version))
 			self.version = package_version
 
-			info (self.get_package_string ())
-
 			return clean_func
 		except Exception as e:
 			if os.path.exists (cache):
@@ -334,6 +332,9 @@ class Package:
 		return self._fetch_sources (profile.build_root, self.workspace, profile.resource_root, profile.source_cache)
 
 	def start_build (self, install_root, stage_root, arch):			
+
+			info (self.get_package_string ())
+
 			profile = Package.profile
 
 			clean_func = retry (self.fetch)

--- a/bockbuild/package.py
+++ b/bockbuild/package.py
@@ -308,7 +308,7 @@ class Package:
 			if os.path.getmtime(s) > mtime:
 				src_txt = src_txt +  ' (Changed)'
 				newer = False
-			info (src_txt)
+			print src_txt
  			
  			# FIXME: There seem to be lots of dirs being touched from other processes.
  			# Must investigate, but turn off subdir checking for now


### PR DESCRIPTION
Before this cosmetic improvement, the download of
a package could happen before its name gets printed,
so it could be confused as a build step of the
previous package.