### PR TITLE
[package] fix building with artifacts from a previous run

### DIFF
--- a/bockbuild/package.py
+++ b/bockbuild/package.py
@@ -159,7 +159,6 @@ class Package:
 			if not os.path.exists(workspace_dir):
 				log (1, 'Cloning a fresh workspace')
 				self.sh ('%' + '{git} clone --local --shared 	"%s" "%s"' % (cache_dir, workspace_dir))
-				self.cd (workspace_dir)
 				clean_func = clean_nop
 			else:
 				clean_func = clean_git_workspace

--- a/bockbuild/package.py
+++ b/bockbuild/package.py
@@ -140,7 +140,7 @@ class Package:
 
 			# Explicitly reset the working dir to a known directory which has not been deleted
 			# 'git clone' does not work if you are in a directory which has been deleted
-			os.chdir (build_root)
+			self.cd (build_root)
 			if not os.path.exists (cache_dir):
 				# since this is a fresh cache, the workspace copy is invalid if it exists
 				if os.path.exists (workspace_dir):
@@ -351,7 +351,7 @@ class Package:
 					run_shell('rsync -a --ignore-existing %s/* %s' % (stagedir, profile.staged_prefix), False)
 
 				else:
-					os.chdir (workspace)
+					self.cd (workspace)
 					self.install ()
 			else:
 				try:


### PR DESCRIPTION
When running bockbuild without removing artifacts from
previous runs (i.e. to save bandwidth by not downloading
tarballs again, or to save CPU to avoid compiling again),
many 'File not found' errors were happening, such as
'../../autoconf.py not found'.

The reason was that ../../autoconf.py is a relative path,
and as such, it's very fragile that the access to it gets
broken by placing calls to os.chdir() everywhere in the
code.

The solution is to:
a) use self.pushd(foo) instead of self.cd(foo), so that we can
b) use self.popd() after we have finished working with 'foo'