### PR TITLE
[package] fix regression about patch downloading

### DIFF
--- a/bockbuild/package.py
+++ b/bockbuild/package.py
@@ -225,9 +225,6 @@ class Package:
 					def checkout_archive (archive, cache, workspace):
 						self.pushd (build_root)
 						if not os.path.exists (cache):
-							# since this is a fresh cache, the workspace copy is invalid if it exists
-							if os.path.exists (workspace):
-								self.rm (workspace)
 							progress ('Downloading: %s' % archive)
 							filename, message = FancyURLopener ().retrieve (archive, cache)
 						if not os.path.exists (workspace):


### PR DESCRIPTION
There are some packages which contain patches in the sources
which need to be retrieved before being applied. Recent
refactoring introduced this bogus call to self.rm() which
would remove the workspace of a package before trying to
download the second source (the workspace is at this point
very important because we have already used tar to extract
what we downloaded in the first source).