### PR TITLE
Add Xamarin.TVOS to supported framework files for PCLs

### DIFF
--- a/packages/pcl-reference-assemblies.py
+++ b/packages/pcl-reference-assemblies.py
@@ -40,8 +40,8 @@ class PCLReferenceAssembliesPackage(Package):
             """<Framework Identifier="MonoAndroid" MinimumVersion="1.0" Profile="*" DisplayName="Xamarin.Android"/>""",
             os.path.join(directory, "Xamarin.Mac.xml"):
             """<Framework Identifier="Xamarin.Mac" MinimumVersion="2.0" Profile="*" DisplayName="Xamarin.Mac Unified"/>""",
-            os.path.join(directory, "Xamarin.tvOS.xml"):
-            """<Framework Identifier="Xamarin.tvOS" MinimumVersion="1.0" Profile="*" DisplayName="Xamarin.tvOS"/>""",
+            os.path.join(directory, "Xamarin.TVOS.xml"):
+            """<Framework Identifier="Xamarin.TVOS" MinimumVersion="1.0" Profile="*" DisplayName="Xamarin.TVOS"/>""",
             os.path.join(directory, "Xamarin.WatchOS.xml"):
             """<Framework Identifier="Xamarin.WatchOS" MinimumVersion="1.0" Profile="*" DisplayName="Xamarin.WatchOS"/>""",
         }


### PR DESCRIPTION
Xamarin.tvOS framework has been renamed to Xamarin.TVOS