### PR TITLE
Include PCL4.6 reference assemblies

### DIFF
--- a/packages/pcl-reference-assemblies.py
+++ b/packages/pcl-reference-assemblies.py
@@ -21,10 +21,9 @@ class PCLReferenceAssembliesPackage(Package):
 
         shutil.rmtree(dest, ignore_errors=True)
 
-        # Omit v4.6 until we support it
         pcldir = os.path.join(self.profile.build_root, self.source_dir_name)
 
-        self.sh("rsync -abv -q --exclude '%s' %s/* %s" % ("v4.6", pcldir, dest))
+        self.sh("rsync -abv -q %s/* %s" % (pcldir, dest))
 
         for f in glob.glob("%s/*/Profile/*/SupportedFrameworks" % dest):
             self.write_xml(f)


### PR DESCRIPTION
Corresponding targets files added to Mono in https://github.com/mono/mono/pull/2199