### PR TITLE
Make Mono package default to 64bit

### DIFF
--- a/bockbuild/package.py
+++ b/bockbuild/package.py
@@ -492,11 +492,11 @@ class Package:
                 self.shadow_copy(workspace_x86, workspace_x64)
 
                 self.link(workspace_x86, workspace)
-                package_stage = self.do_build(
+                stagedir_x32 = self.do_build(
                     'darwin-32', os.path.join(self.profile.bockbuild.scratch, self.name + '-x86.install'))
 
                 self.link(workspace_x64, workspace)
-                stagedir_x64 = self.do_build(
+                package_stage = self.do_build(
                     'darwin-64', os.path.join(self.profile.bockbuild.scratch, self.name + '-x64.install'))
 
                 delete(workspace)
@@ -504,9 +504,9 @@ class Package:
 
                 print 'lipo', self.name
 
-                self.lipo_dirs(stagedir_x64, package_stage, 'lib')
+                self.lipo_dirs(stagedir_x32, package_stage, 'lib')
                 self.copy_side_by_side(
-                    stagedir_x64, package_stage, 'bin', '64', '32')
+                    stagedir_x32, package_stage, 'bin', '32', '64')
             elif arch == 'toolchain':
                 package_stage = self.do_build('darwin-64')
             elif self.m32_only:
@@ -864,14 +864,17 @@ class Package:
                 dest_orig_file = os.path.join(dest_dir, reldir, filename)
 
                 if not os.path.exists(dest_orig_file):
-                    error('lipo: %s exists in %s but not in %s' %
+                    warn('lipo: %s exists in %s but not in %s' %
                           (relpath, src_dir, dest_dir))
-                if orig_suffix is not None:
+                elif orig_suffix is not None:
                     suffixed = os.path.join(
                         dest_dir, reldir, add_suffix(filename, orig_suffix))
                     trace(suffixed)
                     shutil.move(dest_orig_file, suffixed)
                     os.symlink(os.path.basename(suffixed), dest_orig_file)
+
+                if not os.path.exists(os.path.dirname(dest_file)):
+                    os.makedirs(os.path.dirname(dest_file))
 
                 shutil.copy2(path, dest_file)
 


### PR DESCRIPTION
This got regressed when moving to the public bockbuild.
It's basically a port of the revert of https://github.com/xamarin/bockbuild/commit/c1c4910f98ecbd865432be57cd9784bd1b8e432f

Original commit messages:

- Another copy_side_by_side fix (https://github.com/xamarin/bockbuild/commit/a2050e8a5272ab97bdfc1fec4b7e9dd9de8fbcb6)
- Fix for 'assymetrical' copy_side_by_side (https://github.com/xamarin/bockbuild/commit/a95bfdc8c9b6a902dc0bf5b17235d122e438399c)
- Only try renaming side-by-side second copy when the second copy exists (https://github.com/xamarin/bockbuild/commit/7d1d4ad083c65376d7d73c12e398b9a31ba9305b)
- Convert an assert error into a warning. The Mono package builds the executable 'mono-boehm' only under 32-bit arch. (https://github.com/xamarin/bockbuild/commit/7d1d4ad083c65376d7d73c12e398b9a31ba9305b)
- Switch default architecture in lipoed packages -> 64-bit (https://github.com/xamarin/bockbuild/commit/d8d142e3809b8b202d5f38dbab06d514884afc32)

Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=57001