### PR TITLE
[gtk] Use TISCopyCurrentASCIICapableKeyboardInputSource()

### DIFF
--- a/packages/gtk+.py
+++ b/packages/gtk+.py
@@ -199,7 +199,7 @@ class GtkPackage (GnomeGitPackage):
                 'patches/gtk/0001-A11y-Make-GtkTable-emit-the-container-add-signal.patch',
 
 		# https://bugzilla.xamarin.com/show_bug.cgi?id=5162
-		'packages/patches/gtk/get-ascii-capable-keyboard-input-source.patch'
+		'patches/gtk/get-ascii-capable-keyboard-input-source.patch'
             ])
 
     def prep(self):

--- a/packages/gtk+.py
+++ b/packages/gtk+.py
@@ -196,7 +196,10 @@ class GtkPackage (GnomeGitPackage):
                 # https://bugzilla.xamarin.com/show_bug.cgi?id=51382
                 # https://bugzilla.xamarin.com/show_bug.cgi?id=51375
                 'patches/gtk/recompute-viewport-allocation-for-overlay-scrollbars.patch',
-                'patches/gtk/0001-A11y-Make-GtkTable-emit-the-container-add-signal.patch'
+                'patches/gtk/0001-A11y-Make-GtkTable-emit-the-container-add-signal.patch',
+
+		# https://bugzilla.xamarin.com/show_bug.cgi?id=5162
+		'packages/patches/gtk/get-ascii-capable-keyboard-input-source.patch'
             ])
 
     def prep(self):

--- a/packages/patches/gtk/get-ascii-capable-keyboard-input-source.patch
+++ b/packages/patches/gtk/get-ascii-capable-keyboard-input-source.patch
@@ -1,0 +1,23 @@
+commit 2ebbf21fcd13d810bb7a2e6adde011f19033e9b7
+Author: Cody Russell <cody@jhu.edu>
+Date:   Sat Jul 8 15:17:28 2017 -0500
+
+    [Mac] Use TISCopyCurrentASCIICapableKeyboardInputSource()
+    
+    Instead of TISCopyCurrentKeyboardLayoutInputSource(). This seems
+    to fix issues with some Cyrillic keyboard layouts not being able to
+    type shortcuts like Cmd-A, Cmd-S, etc.
+
+diff --git a/gdk/quartz/gdkkeys-quartz.c b/gdk/quartz/gdkkeys-quartz.c
+index 523aaf7e50..7d3e03c2b7 100644
+--- a/gdk/quartz/gdkkeys-quartz.c
++++ b/gdk/quartz/gdkkeys-quartz.c
+@@ -272,7 +272,7 @@ update_keymap (void)
+    * 64-bit.
+    */
+ #ifdef __LP64__
+-  TISInputSourceRef new_layout = TISCopyCurrentKeyboardLayoutInputSource ();
++  TISInputSourceRef new_layout = TISCopyCurrentASCIICapableKeyboardInputSource();
+   CFDataRef layout_data_ref;
+ 
+ #else


### PR DESCRIPTION
Instead of TISCopyCurrentKeyboardLayoutInputSource(). This seems
to fix issues with some Cyrillic keyboard layouts not being able
to type shortcuts like Cmd-A, Cmd-S, etc.

https://bugzilla.xamarin.com/show_bug.cgi?id=5162