### PR TITLE
[gtk] Disable the ascii capable keyboard patch (for now).

### DIFF
--- a/packages/gtk+.py
+++ b/packages/gtk+.py
@@ -202,7 +202,7 @@ class GtkPackage (GnomeGitPackage):
                 # 'patches/gtk/gtk-new-screen-updates-api.patch',
 
                 # https://bugzilla.xamarin.com/show_bug.cgi?id=5162
-                'patches/gtk/get-ascii-capable-keyboard-input-source.patch'
+                # 'patches/gtk/get-ascii-capable-keyboard-input-source.patch'
             ])
 
     def prep(self):


### PR DESCRIPTION
This is unfortunate, the patch fixes shortcut keys in Cyrillic keyboard layouts but it's causing crashers using the 3rd party Google Japanese input source. I made a patch based on https://github.com/mono/bockbuild/pull/45 which solves the crasher but then Cyrillic keyboards were broken again.

I'll investigate a solution, but for now we should disable this.