### PR TITLE
Environment.set(key,val): Expand env vars in the value

### DIFF
--- a/bockbuild/environment.py
+++ b/bockbuild/environment.py
@@ -12,7 +12,7 @@ class EnvironmentItem:
         self.values = values
 
     def __str__(self):
-        return self.joinchar.join(self.values)
+        return os.path.expandvars(self.joinchar.join(self.values))
 
 
 class Environment:


### PR DESCRIPTION
Given,
	env.set('XDG_CONFIG_HOME', '$HOME/.config')

.. then the value got exported as the literal string
`$HOME/.config`, with no shell expansion. And any subprocess would get
the unexpanded value for that env var.

This broke msbuild build on jenkins, because of ..

	bockbuild/unixprofile.py:        self.env.set('XDG_CONFIG_HOME', '$HOME/.config')

.. and this being surfaced to nuget via mono's
`Environment.SpecialFolder.ApplicationData`. The nuget tasks treated the
`"$HOME/.config"` string as a relative path, causing build breakage.

For reference: https://github.com/mono/mono/pull/9112#issuecomment-397138139