### PR TITLE
[gtk] When focusing out, commit the preedit instead of discarding

### DIFF
--- a/packages/gtk+.py
+++ b/packages/gtk+.py
@@ -210,7 +210,10 @@ class GtkPackage (GitHubPackage):
 
                 'patches/gtk/gtk-backing-scale-factor.patch',
 
-                'patches/gtk/gtk-fix-find_nsview_at_pos-recursive.patch'
+                'patches/gtk/gtk-fix-find_nsview_at_pos-recursive.patch',
+
+		# https://devdiv.visualstudio.com/DevDiv/_workitems/edit/569768
+		'patches/gtk/gtk-imquartz-commit-on-focus-out.patch'
             ])
 
     def prep(self):

--- a/packages/patches/gtk/gtk-imquartz-commit-on-focus-out.patch
+++ b/packages/patches/gtk/gtk-imquartz-commit-on-focus-out.patch
@@ -1,0 +1,44 @@
+commit 5358d331a5a01fd7d11297b1686293251fd93197
+Author: Cody Russell <cody@jhu.edu>
+Date:   Tue Jun 26 23:01:29 2018 -0500
+
+    When focusing out, commit the preedit instead of discarding.
+    
+    Fixes VSTS #569768
+
+diff --git a/modules/input/imquartz.c b/modules/input/imquartz.c
+index c93330f22..7829929ac 100644
+--- a/modules/input/imquartz.c
++++ b/modules/input/imquartz.c
+@@ -277,6 +277,22 @@ quartz_reset (GtkIMContext *context)
+   discard_preedit (context);
+ }
+ 
++static void
++quartz_commit (GtkIMContext *context)
++{
++  GtkIMContextQuartz *qc = GTK_IM_CONTEXT_QUARTZ (context);
++  NSView *nsview;
++  GdkWindow *window;
++
++  if (!qc->client_window)
++    return;
++
++  nsview = gdk_quartz_window_get_nsview (qc->client_window);
++  window = (GdkWindow *)[(GdkQuartzView *)nsview gdkWindow];
++
++  output_result (context, window);
++}
++
+ static void
+ quartz_set_client_window (GtkIMContext *context, GdkWindow *window)
+ {
+@@ -305,7 +321,7 @@ quartz_focus_out (GtkIMContext *context)
+   qc->focused = FALSE;
+ 
+   /* Commit any partially built strings or it'll mess up other GTK+ widgets in the window */
+-  discard_preedit (context);
++  quartz_commit (context);
+ }
+ 
+ static void


### PR DESCRIPTION
Fixes VSTS #569768

In the GTK sources there is a comment that says `Commit any partially built strings or it'll mess up other GTK+ widgets in the window`, but the next line after that discards the preedit instead of committing it. When I changed it to actually commit then this appeared to fix the bug.

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/569768