### PR TITLE
[2018-02] Backport some GTK patches

### DIFF
--- a/packages/gtk+.py
+++ b/packages/gtk+.py
@@ -206,7 +206,9 @@ class GtkPackage (GitHubPackage):
                 # 'patches/gtk/get-ascii-capable-keyboard-input-source.patch',
 
                 # https://developercommunity.visualstudio.com/content/problem/104471/visual-studio-for-mac-720540-cannot-launch-exc-bre.html
-                'patches/gtk/update_only_apple_keyboard_layout.patch'
+                'patches/gtk/update_only_apple_keyboard_layout.patch',
+
+                'patches/gtk/gtk-backing-scale-factor.patch'
             ])
 
     def prep(self):

--- a/packages/gtk+.py
+++ b/packages/gtk+.py
@@ -208,7 +208,9 @@ class GtkPackage (GitHubPackage):
                 # https://developercommunity.visualstudio.com/content/problem/104471/visual-studio-for-mac-720540-cannot-launch-exc-bre.html
                 'patches/gtk/update_only_apple_keyboard_layout.patch',
 
-                'patches/gtk/gtk-backing-scale-factor.patch'
+                'patches/gtk/gtk-backing-scale-factor.patch',
+
+                'patches/gtk-fix-find_nsview_at_pos-recursive.patch'
             ])
 
     def prep(self):

--- a/packages/gtk+.py
+++ b/packages/gtk+.py
@@ -210,7 +210,10 @@ class GtkPackage (GitHubPackage):
 
                 'patches/gtk/gtk-backing-scale-factor.patch',
 
-                'patches/gtk/gtk-fix-find_nsview_at_pos-recursive.patch'
+                'patches/gtk/gtk-fix-find_nsview_at_pos-recursive.patch',
+
+		# https://devdiv.visualstudio.com/DevDiv/_workitems/edit/569768
+		'patches/gtk/gtk-imquartz-commit-on-focus-out.patch'
             ])
 
     def prep(self):

--- a/packages/gtk+.py
+++ b/packages/gtk+.py
@@ -210,7 +210,7 @@ class GtkPackage (GitHubPackage):
 
                 'patches/gtk/gtk-backing-scale-factor.patch',
 
-                'patches/gtk-fix-find_nsview_at_pos-recursive.patch'
+                'patches/gtk/gtk-fix-find_nsview_at_pos-recursive.patch'
             ])
 
     def prep(self):

--- a/packages/patches/gtk/gtk-backing-scale-factor.patch
+++ b/packages/patches/gtk/gtk-backing-scale-factor.patch
@@ -1,0 +1,47 @@
+diff --git a/gdk/quartz/gdkscreen-quartz.c b/gdk/quartz/gdkscreen-quartz.c
+index e6f0c44e7..3daad2d6e 100644
+--- a/gdk/quartz/gdkscreen-quartz.c
++++ b/gdk/quartz/gdkscreen-quartz.c
+@@ -83,13 +83,16 @@ _gdk_screen_quartz_init (GdkScreenQuartz *screen_quartz)
+ {
+   GdkScreen *screen = GDK_SCREEN (screen_quartz);
+   NSScreen *nsscreen;
++  NSDictionary *dd;
++  NSSize size;
+ 
+   gdk_screen_set_default_colormap (screen,
+                                    gdk_screen_get_system_colormap (screen));
+ 
+   nsscreen = [[NSScreen screens] objectAtIndex:0];
+-  gdk_screen_set_resolution (screen,
+-                             72.0 * [nsscreen userSpaceScaleFactor]);
++  dd = [nsscreen deviceDescription];
++  size = [[dd valueForKey:NSDeviceResolution] sizeValue];
++  gdk_screen_set_resolution (screen, size.width / [nsscreen backingScaleFactor]);
+ 
+   gdk_screen_quartz_calculate_layout (screen_quartz);
+ 
+@@ -357,17 +360,12 @@ gdk_screen_get_height (GdkScreen *screen)
+ static gint
+ get_mm_from_pixels (NSScreen *screen, int pixels)
+ {
+-  /* userSpaceScaleFactor is in "pixels per point", 
+-   * 72 is the number of points per inch, 
+-   * and 25.4 is the number of millimeters per inch.
+-   */
+-#if MAC_OS_X_VERSION_MAX_ALLOWED > MAC_OS_X_VERSION_10_3
+-  float dpi = [screen userSpaceScaleFactor] * 72.0;
+-#else
+-  float dpi = 96.0 / 72.0;
+-#endif
+-
+-  return (pixels / dpi) * 25.4;
++  const float mm_per_inch = 25.4;
++  NSScreen *nsscreen = [[NSScreen screens] objectAtIndex:0];
++  NSDictionary *dd = [nsscreen deviceDescription];
++  NSSize size = [[dd valueForKey:NSDeviceResolution] sizeValue];
++  float dpi = size.width / [nsscreen backingScaleFactor];
++  return (pixels / dpi) * mm_per_inch;
+ }
+ 
+ static NSScreen *

--- a/packages/patches/gtk/gtk-fix-find_nsview_at_pos-recursive.patch
+++ b/packages/patches/gtk/gtk-fix-find_nsview_at_pos-recursive.patch
@@ -1,0 +1,13 @@
+diff --git a/gdk/quartz/gdkevents-quartz.c b/gdk/quartz/gdkevents-quartz.c
+index 195899b13b..844128e0b2 100644
+--- a/gdk/quartz/gdkevents-quartz.c
++++ b/gdk/quartz/gdkevents-quartz.c
+@@ -748,7 +748,7 @@ find_nsview_at_pos (GdkWindowImplQuartz *impl, gint x, gint y)
+       if (r.origin.x <= x && r.origin.x + r.size.width >= x &&
+           r.origin.y <= y && r.origin.y + r.size.height >= y)
+         {
+-          NSView* child = find_nsview_at_pos (impl, x - r.origin.x, y - r.origin.y);
++          NSView* child = find_nsview_at_pos (sv, x - r.origin.x, y - r.origin.y);
+           if (child != NULL)
+             return child;
+           else

--- a/packages/patches/gtk/gtk-imquartz-commit-on-focus-out.patch
+++ b/packages/patches/gtk/gtk-imquartz-commit-on-focus-out.patch
@@ -1,0 +1,44 @@
+commit 5358d331a5a01fd7d11297b1686293251fd93197
+Author: Cody Russell <cody@jhu.edu>
+Date:   Tue Jun 26 23:01:29 2018 -0500
+
+    When focusing out, commit the preedit instead of discarding.
+    
+    Fixes VSTS #569768
+
+diff --git a/modules/input/imquartz.c b/modules/input/imquartz.c
+index c93330f22..7829929ac 100644
+--- a/modules/input/imquartz.c
++++ b/modules/input/imquartz.c
+@@ -277,6 +277,22 @@ quartz_reset (GtkIMContext *context)
+   discard_preedit (context);
+ }
+ 
++static void
++quartz_commit (GtkIMContext *context)
++{
++  GtkIMContextQuartz *qc = GTK_IM_CONTEXT_QUARTZ (context);
++  NSView *nsview;
++  GdkWindow *window;
++
++  if (!qc->client_window)
++    return;
++
++  nsview = gdk_quartz_window_get_nsview (qc->client_window);
++  window = (GdkWindow *)[(GdkQuartzView *)nsview gdkWindow];
++
++  output_result (context, window);
++}
++
+ static void
+ quartz_set_client_window (GtkIMContext *context, GdkWindow *window)
+ {
+@@ -305,7 +321,7 @@ quartz_focus_out (GtkIMContext *context)
+   qc->focused = FALSE;
+ 
+   /* Commit any partially built strings or it'll mess up other GTK+ widgets in the window */
+-  discard_preedit (context);
++  quartz_commit (context);
+ }
+ 
+ static void


### PR DESCRIPTION
This is to backport the following changes to 2018-02

https://github.com/mono/bockbuild/pull/66
https://github.com/mono/bockbuild/pull/68
https://github.com/mono/bockbuild/pull/63
