### PR TITLE
[runtime] Fix reference to C compiler, 'xcrun gcc' fails when building llvm

### DIFF
--- a/bockbuild/darwinprofile.py
+++ b/bockbuild/darwinprofile.py
@@ -122,11 +122,11 @@ class DarwinProfile (UnixProfile):
             self.gcc_flags.extend(['-O0', '-ggdb3'])
 
         if os.getenv('BOCKBUILD_USE_CCACHE') is None:
-            self.env.set('CC',  'xcrun gcc')
-            self.env.set('CXX', 'xcrun g++')
+            self.env.set('CC',  'xcrun clang')
+            self.env.set('CXX', 'xcrun clang++')
         else:
-            self.env.set('CC',  'ccache xcrun gcc')
-            self.env.set('CXX', 'ccache xcrun g++')
+            self.env.set('CC',  'ccache xcrun clang')
+            self.env.set('CXX', 'ccache xcrun clang++')
 
         if self.bockbuild.cmd_options.arch == 'default':
             self.bockbuild.cmd_options.arch = 'darwin-32'


### PR DESCRIPTION
It should be noted that both point to the same binary: clang. The GCC alias tells clang to use libstdc++. Apple has ceased development of that library in favor of libc++. The functions added to libc++ that have not been backported to libstdc++ causes llvm to fail to build on CI today