### PR TITLE
[GTK] Disable this patch for now to fix crasher.

### DIFF
--- a/packages/gtk+.py
+++ b/packages/gtk+.py
@@ -210,7 +210,7 @@ class GtkPackage (GitHubPackage):
 
                 'patches/gtk/gtk-backing-scale-factor.patch',
 
-                'patches/gtk/gtk-fix-find_nsview_at_pos-recursive.patch',
+                #'patches/gtk/gtk-fix-find_nsview_at_pos-recursive.patch',
 
 		# https://devdiv.visualstudio.com/DevDiv/_workitems/edit/569768
 		'patches/gtk/gtk-imquartz-commit-on-focus-out.patch'


### PR DESCRIPTION
https://github.com/mono/mono/issues/9592

I don't have a proper fix yet, so for now can we just disable this patch?