### PR TITLE
[Gtk] Patch Gtk to popup the menu when using the arrow keys

### DIFF
--- a/packages/gtk+.py
+++ b/packages/gtk+.py
@@ -217,7 +217,8 @@ class GtkPackage (GitHubPackage):
 
 		# https://devdiv.visualstudio.com/DevDiv/_workitems/edit/737323
 		'patches/gtk/gtk-nsview-subview-focus-fixes.patch',
-		'patches/gtk/gtk-nsview-focus-tabbing.patch'
+		'patches/gtk/gtk-nsview-focus-tabbing.patch',
+		'patches/gtk/popup-combo-box-with-arrows.patch'
             ])
 
     def prep(self):

--- a/packages/patches/gtk/popup-combo-box-with-arrows.patch
+++ b/packages/patches/gtk/popup-combo-box-with-arrows.patch
@@ -1,0 +1,39 @@
+diff --git a/gtk/gtkcombobox.c b/gtk/gtkcombobox.c
+index bd83a1e11..417799535 100644
+--- a/gtk/gtkcombobox.c
++++ b/gtk/gtkcombobox.c
+@@ -651,18 +651,19 @@ gtk_combo_box_class_init (GtkComboBoxClass *klass)
+   /* key bindings */
+   binding_set = gtk_binding_set_by_class (widget_class);
+ 
+-  gtk_binding_entry_add_signal (binding_set, GDK_Down, GDK_MOD1_MASK,
++  gtk_binding_entry_add_signal (binding_set, GDK_Down, 0,
+ 				"popup", 0);
+-  gtk_binding_entry_add_signal (binding_set, GDK_KP_Down, GDK_MOD1_MASK,
++  gtk_binding_entry_add_signal (binding_set, GDK_KP_Down, 0,
+ 				"popup", 0);
+ 
+-  gtk_binding_entry_add_signal (binding_set, GDK_Up, GDK_MOD1_MASK,
+-				"popdown", 0);
+-  gtk_binding_entry_add_signal (binding_set, GDK_KP_Up, GDK_MOD1_MASK,
+-				"popdown", 0);
++  gtk_binding_entry_add_signal (binding_set, GDK_Up, 0,
++				"popup", 0);
++  gtk_binding_entry_add_signal (binding_set, GDK_KP_Up, 0,
++				"popup", 0);
+   gtk_binding_entry_add_signal (binding_set, GDK_Escape, 0,
+ 				"popdown", 0);
+ 
++#if 0
+   gtk_binding_entry_add_signal (binding_set, GDK_Up, 0,
+ 				"move-active", 1,
+ 				GTK_TYPE_SCROLL_TYPE, GTK_SCROLL_STEP_UP);
+@@ -700,7 +701,7 @@ gtk_combo_box_class_init (GtkComboBoxClass *klass)
+   gtk_binding_entry_add_signal (binding_set, GDK_KP_End, 0,
+ 				"move-active", 1,
+ 				GTK_TYPE_SCROLL_TYPE, GTK_SCROLL_END);
+-
++#endif
+   /* properties */
+   g_object_class_override_property (object_class,
+                                     PROP_EDITING_CANCELED,


### PR DESCRIPTION
Changes the behaviour of GtkComboBox to match the behaviour of NSPopupButton and NSComboBox in Cocoa

Fixes VSTS #752354