### PR TITLE
[bockbuild] Add gtk-sharp patch to fix build with mcs

### DIFF
--- a/packages/gtk-sharp.py
+++ b/packages/gtk-sharp.py
@@ -9,6 +9,15 @@ class GtkSharp212ReleasePackage (Package):
                              'configure': './bootstrap-2.12 --prefix=%{package_prefix}',
                          }
                          )
+        self.sources.extend([
+            'patches/gtk-sharp-range.patch'
+            ])
         self.make = 'make CSC=mcs'
+
+    def prep(self):
+        Package.prep(self)
+
+        for p in range(1, len(self.sources)):
+            self.sh('patch -p1 < "%{local_sources[' + str(p) + ']}"')
 
 GtkSharp212ReleasePackage()

--- a/packages/patches/gtk-sharp-range.patch
+++ b/packages/patches/gtk-sharp-range.patch
@@ -1,0 +1,13 @@
+diff --git a/sample/test/TestRange.cs b/sample/test/TestRange.cs
+index 82fb81105..3da945e69 100644
+--- a/sample/test/TestRange.cs
++++ b/sample/test/TestRange.cs
+@@ -9,6 +9,8 @@
+ using System;
+ 
+ using Gtk;
++// disambiguate, Gtk.Range vs System.Range
++using Range=Gtk.Range;
+ 
+ namespace WidgetViewer {
+ 


### PR DESCRIPTION
Recent addition of C#8 features to mcs possibly broke this:

```
mcs -out:WidgetViewer.exe -r:../../glib/glib-sharp.dll -r:../../pango/pango-sharp.dll -r:../../atk/atk-sharp.dll -r:../../gdk/gdk-sharp.dll -r:../../gtk/gtk-sharp.dll ./TestCheckButton.cs ./TestColorSelection.cs ./TestRadioButton.cs ./TestRange.cs ./TestStatusbar.cs ./TestDialog.cs ./TestFlipping.cs ./TestSizeGroup.cs ./TestCombo.cs ./TestComboBox.cs ./WidgetViewer.cs
./TestCombo.cs(17,14): warning CS0612: `Gtk.Combo' is obsolete
./TestRange.cs(35,6): error CS0104: `Range' is an ambiguous reference between `System.Range' and `Gtk.Range'
@/external/bockbuild/stage/lib/mono/4.5/mscorlib.dll (Location of the symbol related to previous error)
@/external/bockbuild/builds/gtk-sharp-None/sample/test/../../gtk/gtk-sharp.dll (Location of the symbol related to previous error)
./TestRange.cs(35,13): error CS0030: Cannot convert type `Gtk.HScale' to `System.Range'
./TestRange.cs(42,6): error CS0104: `Range' is an ambiguous reference between `System.Range' and `Gtk.Range'
@/external/bockbuild/stage/lib/mono/4.5/mscorlib.dll (Location of the symbol related to previous error)
@/external/bockbuild/builds/gtk-sharp-None/sample/test/../../gtk/gtk-sharp.dll (Location of the symbol related to previous error)
./TestRange.cs(42,13): error CS0030: Cannot convert type `Gtk.HScrollbar' to `System.Range'
./TestRange.cs(62,6): error CS0104: `Range' is an ambiguous reference between `System.Range' and `Gtk.Range'
@/external/bockbuild/stage/lib/mono/4.5/mscorlib.dll (Location of the symbol related to previous error)
@/external/bockbuild/builds/gtk-sharp-None/sample/test/../../gtk/gtk-sharp.dll (Location of the symbol related to previous error)
./TestRange.cs(62,13): error CS0030: Cannot convert type `Gtk.VScale' to `System.Range'
```

This is because the compiler is resolving `Range` in the test as `System.Range`
instead of `Gtk.Range`, so we disambiguate it.

/cc @marek-safar