### PR TITLE
[Gdk] Prevent GdkQuartzWindow having its delegate replaced.

### DIFF
--- a/packages/gtk+.py
+++ b/packages/gtk+.py
@@ -218,7 +218,8 @@ class GtkPackage (GitHubPackage):
 		# https://devdiv.visualstudio.com/DevDiv/_workitems/edit/737323
 		'patches/gtk/gtk-nsview-subview-focus-fixes.patch',
 		'patches/gtk/gtk-nsview-focus-tabbing.patch',
-		'patches/gtk/popup-combo-box-with-arrows.patch'
+		'patches/gtk/popup-combo-box-with-arrows.patch',
+		'patches/gtk/0001-prevent-gdk-quartz-window-delegate-replacement.patch'
             ])
 
     def prep(self):

--- a/packages/patches/gtk/0001-prevent-gdk-quartz-window-delegate-replacement.patch
+++ b/packages/patches/gtk/0001-prevent-gdk-quartz-window-delegate-replacement.patch
@@ -1,0 +1,271 @@
+diff --git a/gdk/quartz/GdkQuartzWindow.c b/gdk/quartz/GdkQuartzWindow.c
+index e8e0de5c7..435c856be 100644
+--- a/gdk/quartz/GdkQuartzWindow.c
++++ b/gdk/quartz/GdkQuartzWindow.c
+@@ -259,6 +259,16 @@
+   return [super makeFirstResponder:responder];
+ }
+ 
++-(void)setDelegate:(id<NSWindowDelegate>)delegate
++{
++  if ([super delegate] == nil) {
++    [super setDelegate:delegate];
++  } else {
++    // If we allow the window delegate to be replaced, everything breaks.
++    g_critical ("Setting a delegate on GdkQuartzWindow is forbidden, because everything will break.");
++  }
++}
++
+ -(id)initWithContentRect:(NSRect)contentRect styleMask:(NSUInteger)styleMask backing:(NSBackingStoreType)backingType defer:(BOOL)flag screen:(NSScreen *)screen
+ {
+   self = [super initWithContentRect:contentRect
+diff --git a/gtk/gtkcombobox.c b/gtk/gtkcombobox.c
+index bd83a1e11..417799535 100644
+--- a/gtk/gtkcombobox.c
++++ b/gtk/gtkcombobox.c
+@@ -651,18 +651,19 @@ gtk_combo_box_class_init (GtkComboBoxClass *klass)
+   /* key bindings */
+   binding_set = gtk_binding_set_by_class (widget_class);
+ 
+-  gtk_binding_entry_add_signal (binding_set, GDK_Down, GDK_MOD1_MASK,
++  gtk_binding_entry_add_signal (binding_set, GDK_Down, 0,
+ 				"popup", 0);
+-  gtk_binding_entry_add_signal (binding_set, GDK_KP_Down, GDK_MOD1_MASK,
++  gtk_binding_entry_add_signal (binding_set, GDK_KP_Down, 0,
+ 				"popup", 0);
+ 
+-  gtk_binding_entry_add_signal (binding_set, GDK_Up, GDK_MOD1_MASK,
+-				"popdown", 0);
+-  gtk_binding_entry_add_signal (binding_set, GDK_KP_Up, GDK_MOD1_MASK,
+-				"popdown", 0);
++  gtk_binding_entry_add_signal (binding_set, GDK_Up, 0,
++				"popup", 0);
++  gtk_binding_entry_add_signal (binding_set, GDK_KP_Up, 0,
++				"popup", 0);
+   gtk_binding_entry_add_signal (binding_set, GDK_Escape, 0,
+ 				"popdown", 0);
+ 
++#if 0
+   gtk_binding_entry_add_signal (binding_set, GDK_Up, 0,
+ 				"move-active", 1,
+ 				GTK_TYPE_SCROLL_TYPE, GTK_SCROLL_STEP_UP);
+@@ -700,7 +701,7 @@ gtk_combo_box_class_init (GtkComboBoxClass *klass)
+   gtk_binding_entry_add_signal (binding_set, GDK_KP_End, 0,
+ 				"move-active", 1,
+ 				GTK_TYPE_SCROLL_TYPE, GTK_SCROLL_END);
+-
++#endif
+   /* properties */
+   g_object_class_override_property (object_class,
+                                     PROP_EDITING_CANCELED,
+diff --git a/gtk/gtknsview.c b/gtk/gtknsview.c
+index a4b4dd4db..6c2eb7454 100644
+--- a/gtk/gtknsview.c
++++ b/gtk/gtknsview.c
+@@ -49,6 +49,7 @@ enum
+ struct _GtkNSViewPrivate
+ {
+   NSView *view;
++  NSResponder *responder;
+   guint   map_timeout;
+   gboolean enable_swizzle;
+ };
+@@ -442,15 +443,29 @@ gtk_ns_view_replace_draw_insertion_point (void)
+     }
+ }
+ 
++gboolean
++does_accept_first_responder_recursively (NSView *view)
++{
++  if ([view acceptsFirstResponder]) {
++    return TRUE;
++  }
++
++  for (NSView *subview in [view subviews]) {
++    return does_accept_first_responder_recursively (subview);
++  }
++
++  return FALSE;
++}
++
+ static void
+ gtk_ns_view_constructed (GObject *object)
+ {
+   GtkNSView *ns_view = GTK_NS_VIEW (object);
++  gboolean can_focus = does_accept_first_responder_recursively (ns_view->priv->view);
+ 
+   G_OBJECT_CLASS (gtk_ns_view_parent_class)->constructed (object);
+ 
+-  gtk_widget_set_can_focus (GTK_WIDGET (ns_view),
+-                            [ns_view->priv->view acceptsFirstResponder]);
++  gtk_widget_set_can_focus (GTK_WIDGET (ns_view), can_focus);
+ 
+ #if DEBUG_FOCUS
+   g_printerr ("%s can focus: %d\n",
+@@ -548,11 +563,11 @@ gtk_ns_view_notify (GObject    *object,
+                   class_getName ([ns_view->priv->view class]),
+                   gtk_widget_has_focus (GTK_WIDGET (object)));
+ #endif
+-
+-      if (gtk_widget_has_focus (GTK_WIDGET (object)))
+-        [ns_window makeFirstResponder:ns_view->priv->view];
+-      else if ([ns_window firstResponder] == ns_view->priv->view || (GTK_IS_WINDOW (toplevel) && !gtk_window_is_active (GTK_WINDOW (toplevel))))
+-        [ns_window makeFirstResponder:nil];
++      if (gtk_widget_has_focus (GTK_WIDGET (object))) {
++          [ns_window makeFirstResponder:(ns_view->priv->responder ? ns_view->priv->responder : ns_view->priv->view)];
++      } else if ([ns_window firstResponder] == ns_view->priv->view || (GTK_IS_WINDOW (toplevel) && !gtk_window_is_active (GTK_WINDOW (toplevel)))) {
++          [ns_window makeFirstResponder:nil];
++      }
+     }
+ }
+ 
+@@ -703,16 +718,38 @@ gtk_ns_view_size_allocate (GtkWidget     *widget,
+     gtk_ns_view_position_view (ns_view, allocation);
+ }
+ 
++static NSResponder *
++find_responder (NSResponder *firstResponder)
++{
++  if (firstResponder == nil) {
++    NSLog (@"No first responder");
++    return nil;
++  }
++  
++  if ([firstResponder acceptsFirstResponder]) {
++    NSLog (@"%@ accepts first responder", firstResponder);
++  } else {
++    NSLog (@"%@ does not accept first responder", firstResponder);
++  }
++
++  return find_responder ([firstResponder nextResponder]);
++}
++
+ static void
+ gtk_ns_view_grab_focus (GtkWidget *widget)
+ {
+   GtkNSView *ns_view = GTK_NS_VIEW (widget);
+   NSWindow *ns_window;
+ 
++  NSLog (@"Grabbing focus");
+   GTK_WIDGET_CLASS (gtk_ns_view_parent_class)->grab_focus (widget);
+ 
+   ns_window = [ns_view->priv->view window];
+-  [ns_window makeFirstResponder:ns_view->priv->view];
++
++  NSLog (@"responder: %@", find_responder ([ns_window firstResponder]));
++  NSLog (@"Widget responder: %@", ns_view->priv->responder);
++  NSLog (@"Widget view: %@", ns_view->priv->view);
++  [ns_window makeFirstResponder:ns_view->priv->responder != NULL ? ns_view->priv->responder : ns_view->priv->view];
+ }
+ 
+ static gboolean
+@@ -722,54 +759,17 @@ gtk_ns_view_key_press (GtkWidget   *widget,
+   GtkNSView *ns_view = GTK_NS_VIEW (widget);
+   NSEvent *nsevent = gdk_quartz_event_get_nsevent ((GdkEvent *) event);
+ 
+-  if (gtk_ns_view_forward_event (widget, event))
+-    {
+-      NSWindow *ns_window = [ns_view->priv->view window];
+-      NSResponder *responder = [ns_window firstResponder];
+-
+-      gint command_mask = gdk_quartz_get_fix_modifiers () ? GDK_MOD2_MASK : GDK_MOD1_MASK;
++  if ([nsevent type] != NSEventTypeKeyDown) {
++    return GTK_WIDGET_CLASS (gtk_ns_view_parent_class)->key_press_event (widget, event);
++  }
+ 
+-      if ([responder isKindOfClass: [NSTextView class]] &&
+-          (event->state & (GDK_SHIFT_MASK | GDK_CONTROL_MASK |
+-                           GDK_MOD1_MASK | GDK_MOD2_MASK)) == command_mask)
+-        {
+-          NSTextView *text_view = (NSTextView *) responder;
+-          NSRange range = [text_view selectedRange];
+-          gboolean has_selection = range.length > 0;
+-
+-          switch (event->keyval)
+-            {
+-            case GDK_KEY_c: /* copy */
+-              if (has_selection)
+-                [text_view copy: text_view];
+-              return TRUE;
+-
+-            case GDK_KEY_x: /* cut */
+-              if (has_selection)
+-                [text_view cut: text_view];
+-              return TRUE;
+-
+-            case GDK_KEY_v: /* paste */
+-              [text_view paste: text_view];
+-              return TRUE;
+-
+-            case GDK_KEY_a: /* all */
+-              range.location = 0;
+-              range.length = [[text_view string] length];
+-              [text_view setSelectedRange: range];
+-              return TRUE;
+-
+-            default:
+-              break;
+-            }
+-        }
+-      else
+-        {
+-          [ns_window sendEvent:nsevent];
++  NSWindow *ns_window = [ns_view->priv->view window];
++  NSResponder *responder = [ns_window firstResponder];
++  if (responder) {
++    [[ns_window firstResponder] interpretKeyEvents:@[nsevent]];
+ 
+-          return TRUE;
+-        }
+-    }
++    return TRUE;
++  }
+ 
+   return GTK_WIDGET_CLASS (gtk_ns_view_parent_class)->key_press_event (widget, event);
+ }
+@@ -818,15 +818,21 @@ gtk_ns_view_native_child_event (GdkWindow *window,
+ 
+               if (hit &&
+                   (hit == view ||
+-                   [hit ancestorSharedWithView: view] == view) &&
+-                  ([hit acceptsFirstResponder] ||
+-                   [view acceptsFirstResponder]))
++                  [hit ancestorSharedWithView:view] == view))
+                 {
++                  NSResponder *responder = (NSResponder *)hit;
++                  while (responder) {
++                    if ([responder acceptsFirstResponder]) {
++                      break;
++                    }
++                    responder = [responder nextResponder];
++                  }
+ #if DEBUG_FOCUS
+                   g_printerr ("grabbing focus on %s\n",
+                               class_getName ([ns_view->priv->view class]));
+ #endif
+ 
++                  ns_view->priv->responder = responder;
+                   gtk_widget_grab_focus (GTK_WIDGET (ns_view));
+                 }
+             }
+@@ -848,6 +854,8 @@ gtk_ns_view_move_native_children (GdkWindow *window,
+   gtk_ns_view_position_view (ns_view, &allocation);
+ }
+ 
++#define DEBUG_FOCUS 1
++
+ static gboolean
+ gtk_ns_view_forward_event (GtkWidget   *widget,
+                            GdkEventKey *event)
+@@ -886,9 +894,11 @@ gtk_ns_view_forward_event (GtkWidget   *widget,
+       next_key_view != ns_view->priv->view &&
+       [next_key_view isDescendantOf:ns_view->priv->view])
+     {
++      NSLog (@"Return true");
+       return TRUE;
+     }
+ 
++  NSLog (@"Return false");
+   return FALSE;
+ }
+ 


### PR DESCRIPTION
Replacing the GdkQuartzWindow delegate causes bad things to happen. This will
prevent it, and drop a message to console telling you not to.