### PR TITLE
[Gdk] Prevent GdkQuartzWindow having its delegate replaced.

### DIFF
--- a/packages/gtk+.py
+++ b/packages/gtk+.py
@@ -218,7 +218,8 @@ class GtkPackage (GitHubPackage):
 		# https://devdiv.visualstudio.com/DevDiv/_workitems/edit/737323
 		'patches/gtk/gtk-nsview-subview-focus-fixes.patch',
 		'patches/gtk/gtk-nsview-focus-tabbing.patch',
-		'patches/gtk/popup-combo-box-with-arrows.patch'
+		'patches/gtk/popup-combo-box-with-arrows.patch',
+		'patches/gtk/0001-prevent-gdk-quartz-window-delegate-replacement.patch'
             ])
 
     def prep(self):

--- a/packages/patches/gtk/0001-prevent-gdk-quartz-window-delegate-replacement.patch
+++ b/packages/patches/gtk/0001-prevent-gdk-quartz-window-delegate-replacement.patch
@@ -1,0 +1,21 @@
+diff --git a/gdk/quartz/GdkQuartzWindow.c b/gdk/quartz/GdkQuartzWindow.c
+index e8e0de5c7..435c856be 100644
+--- a/gdk/quartz/GdkQuartzWindow.c
++++ b/gdk/quartz/GdkQuartzWindow.c
+@@ -259,6 +259,16 @@
+   return [super makeFirstResponder:responder];
+ }
+ 
++-(void)setDelegate:(id<NSWindowDelegate>)delegate
++{
++  if ([super delegate] == nil) {
++    [super setDelegate:delegate];
++  } else {
++    // If we allow the window delegate to be replaced, everything breaks.
++    g_critical ("Setting a delegate on GdkQuartzWindow is forbidden, because everything will break.");
++  }
++}
++
+ -(id)initWithContentRect:(NSRect)contentRect styleMask:(NSUInteger)styleMask backing:(NSBackingStoreType)backingType defer:(BOOL)flag screen:(NSScreen *)screen
+ {
+   self = [super initWithContentRect:contentRect


### PR DESCRIPTION
Replacing the GdkQuartzWindow delegate causes bad things to happen. This will
prevent it, and drop a message to console telling you not to.