### PR TITLE
Fix NSView embedding events - skip hidden subviews

### DIFF
--- a/packages/gtk+.py
+++ b/packages/gtk+.py
@@ -212,15 +212,18 @@ class GtkPackage (GitHubPackage):
 
                 #'patches/gtk/gtk-fix-find_nsview_at_pos-recursive.patch',
 
-		# https://devdiv.visualstudio.com/DevDiv/_workitems/edit/569768
-		'patches/gtk/gtk-imquartz-commit-on-focus-out.patch',
+                # https://devdiv.visualstudio.com/DevDiv/_workitems/edit/569768
+                'patches/gtk/gtk-imquartz-commit-on-focus-out.patch',
 
-		# https://devdiv.visualstudio.com/DevDiv/_workitems/edit/737323
-		'patches/gtk/gtk-nsview-subview-focus-fixes.patch',
-		'patches/gtk/gtk-nsview-focus-tabbing.patch',
-		'patches/gtk/popup-combo-box-with-arrows.patch',
-		'patches/gtk/0001-prevent-gdk-quartz-window-delegate-replacement.patch',
-		'patches/gtk/0077-fix-nsview-embedding-mouse-move-event-when-popup-window-appears.patch'
+                # https://devdiv.visualstudio.com/DevDiv/_workitems/edit/737323
+                'patches/gtk/gtk-nsview-subview-focus-fixes.patch',
+                'patches/gtk/gtk-nsview-focus-tabbing.patch',
+                'patches/gtk/popup-combo-box-with-arrows.patch',
+                'patches/gtk/0001-prevent-gdk-quartz-window-delegate-replacement.patch',
+                'patches/gtk/0077-fix-nsview-embedding-mouse-move-event-when-popup-window-appears.patch',
+
+                # https://devdiv.visualstudio.com/DevDiv/_workitems/edit/821841
+                'patches/gtk/nsview-embedding-skip-hidden-subviews.patch',
             ])
 
     def prep(self):

--- a/packages/patches/gtk/nsview-embedding-skip-hidden-subviews.patch
+++ b/packages/patches/gtk/nsview-embedding-skip-hidden-subviews.patch
@@ -1,0 +1,26 @@
+From cb62d4a99f228f51ee420f289f741dbb4ecea57b Mon Sep 17 00:00:00 2001
+From: Vsevolod Kukol <sevoku@microsoft.com>
+Date: Mon, 18 Mar 2019 16:15:54 +0100
+Subject: [PATCH] Skip hidden subviews when searching for a child event target
+
+---
+ gdk/quartz/gdkevents-quartz.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/gdk/quartz/gdkevents-quartz.c b/gdk/quartz/gdkevents-quartz.c
+index b5016e1de9..8101e366c8 100644
+--- a/gdk/quartz/gdkevents-quartz.c
++++ b/gdk/quartz/gdkevents-quartz.c
+@@ -724,7 +724,8 @@ find_nsview_at_pos (GdkWindowImplQuartz *impl, gint x, gint y)
+       if (sv == impl->layer_view)
+         continue;
+ 
+-      if (r.origin.x <= x && r.origin.x + r.size.width >= x &&
++      if (![sv isHidden] &&
++          r.origin.x <= x && r.origin.x + r.size.width >= x &&
+           r.origin.y <= y && r.origin.y + r.size.height >= y)
+         {
+           NSView* child = find_nsview_at_pos (impl, x - r.origin.x, y - r.origin.y);
+-- 
+2.17.1 (Apple Git-112)
+


### PR DESCRIPTION
Skip hidden views when trying to find an NSView at the given position.