### PR TITLE
[darwin] Use configure's --build option for 64-bit builds too

### DIFF
--- a/bockbuild/darwinprofile.py
+++ b/bockbuild/darwinprofile.py
@@ -143,7 +143,8 @@ class DarwinProfile (UnixProfile):
         elif arch == 'darwin-64':
             package.local_ld_flags = ['-arch x86_64 -m64']
             package.local_gcc_flags = ['-arch x86_64 -m64']
-            package.local_configure_flags = ['--disable-dependency-tracking']
+            package.local_configure_flags = [
+                '--build=x86_64-apple-darwin13.0.0', '--disable-dependency-tracking']
         else:
             error('Unknown arch %s' % arch)
 


### PR DESCRIPTION
We used to not do that, and the default triple would do just fine, but recently a change has caused the pkg-config package 64-bit build to also result in 32-bit binaries. Explicitly setting the triple remedies this problem