### PR TITLE
[2019-02] iterate_dir: Include symlinks to dirs also

### DIFF
--- a/bockbuild/util/util.py
+++ b/bockbuild/util/util.py
@@ -548,6 +548,12 @@ def iterate_dir(dir, with_links=False, with_dirs=False, summary=False):
         dirs = dirs + 1
         if with_dirs:
             yield root
+        if with_dirs and with_links:
+            for subdir in subdirs:
+                path = os.path.join(root, subdir)
+                if os.path.islink(path):
+                    links = links + 1
+                    yield path
         for file in filelist:
             path = os.path.join(root, file)
             if os.path.islink(path):


### PR DESCRIPTION
Given:
`for root, subdirs, filelist in os.walk(dir):`

.. symlinks to directories are only returned in `subdirs`. So, they need
to handled explicitly.

This meant that when bockbuild tried to zip up the contents of mono and
msbuild to move to the staging directory, then such symlinks were not
picked up thus breaking the build.

(cherry picked from commit 5d818c1af4d10c9325a40aa66dc0c994aa3e1781)