### PR TITLE
[Gtk] Allow Cocoa to unset the delegate when deallocating the window

### DIFF
--- a/packages/patches/gtk/0001-prevent-gdk-quartz-window-delegate-replacement.patch
+++ b/packages/patches/gtk/0001-prevent-gdk-quartz-window-delegate-replacement.patch
@@ -1,14 +1,32 @@
 diff --git a/gdk/quartz/GdkQuartzWindow.c b/gdk/quartz/GdkQuartzWindow.c
-index e8e0de5c7..435c856be 100644
+index e8e0de5c7..63f3402f8 100644
 --- a/gdk/quartz/GdkQuartzWindow.c
 +++ b/gdk/quartz/GdkQuartzWindow.c
-@@ -259,6 +259,16 @@
+@@ -22,7 +22,16 @@
+ #include "gdkwindow-quartz.h"
+ #include "gdkprivate-quartz.h"
+ 
+-@implementation GdkQuartzWindow
++@implementation GdkQuartzWindow {
++  BOOL _allowDelegateToBeSetToNil;
++}
++
++-(void)dealloc
++{
++  // During deallocation, Cocoa resets the delegate to nil
++  // We need to track that so that we don't throw an error
++  _allowDelegateToBeSetToNil = YES;
++}
+ 
+ -(BOOL)windowShouldClose:(id)sender
+ {
+@@ -259,6 +268,16 @@
    return [super makeFirstResponder:responder];
  }
  
 +-(void)setDelegate:(id<NSWindowDelegate>)delegate
 +{
-+  if ([super delegate] == nil) {
++  if ([super delegate] == nil || (_allowDelegateToBeSetToNil && delegate == nil)) {
 +    [super setDelegate:delegate];
 +  } else {
 +    // If we allow the window delegate to be replaced, everything breaks.
@@ -19,3 +37,11 @@ index e8e0de5c7..435c856be 100644
  -(id)initWithContentRect:(NSRect)contentRect styleMask:(NSUInteger)styleMask backing:(NSBackingStoreType)backingType defer:(BOOL)flag screen:(NSScreen *)screen
  {
    self = [super initWithContentRect:contentRect
+@@ -271,6 +290,7 @@
+   [self setDelegate:self];
+   [self setReleasedWhenClosed:YES];
+ 
++  _allowDelegateToBeSetToNil = NO;
+   return self;
+ }
+ 


### PR DESCRIPTION
Cocoa unsets delegates when deallocating the window object, so we need to
allow that and not throw a critical message at that point

Fixes VSTS #935204
Fixes VSTS #935386