### PR TITLE
[Gtk] Allow Cocoa to unset the delegate when deallocating the window

### DIFF
--- a/packages/patches/gtk/0001-prevent-gdk-quartz-window-delegate-replacement.patch
+++ b/packages/patches/gtk/0001-prevent-gdk-quartz-window-delegate-replacement.patch
@@ -1,14 +1,28 @@
 diff --git a/gdk/quartz/GdkQuartzWindow.c b/gdk/quartz/GdkQuartzWindow.c
-index e8e0de5c7..435c856be 100644
+index e8e0de5c7..d0c6e84ec 100644
 --- a/gdk/quartz/GdkQuartzWindow.c
 +++ b/gdk/quartz/GdkQuartzWindow.c
-@@ -259,6 +259,16 @@
+@@ -24,6 +24,13 @@
+ 
+ @implementation GdkQuartzWindow
+ 
++-(void)dealloc
++{
++  // During deallocation, Cocoa resets the delegate to nil
++  // We need to track that so that we don't throw an error
++  _allowDelegateToBeSetToNil = YES;
++}
++
+ -(BOOL)windowShouldClose:(id)sender
+ {
+   GdkWindow *window = [[self contentView] gdkWindow];
+@@ -259,6 +266,16 @@
    return [super makeFirstResponder:responder];
  }
  
 +-(void)setDelegate:(id<NSWindowDelegate>)delegate
 +{
-+  if ([super delegate] == nil) {
++  if ([super delegate] == nil || (_allowDelegateToBeSetToNil && delegate == nil)) {
 +    [super setDelegate:delegate];
 +  } else {
 +    // If we allow the window delegate to be replaced, everything breaks.
@@ -19,3 +33,24 @@ index e8e0de5c7..435c856be 100644
  -(id)initWithContentRect:(NSRect)contentRect styleMask:(NSUInteger)styleMask backing:(NSBackingStoreType)backingType defer:(BOOL)flag screen:(NSScreen *)screen
  {
    self = [super initWithContentRect:contentRect
+@@ -271,6 +288,7 @@
+   [self setDelegate:self];
+   [self setReleasedWhenClosed:YES];
+ 
++  _allowDelegateToBeSetToNil = NO;
+   return self;
+ }
+ 
+diff --git a/gdk/quartz/GdkQuartzWindow.h b/gdk/quartz/GdkQuartzWindow.h
+index 928f9617e..23cde0037 100644
+--- a/gdk/quartz/GdkQuartzWindow.h
++++ b/gdk/quartz/GdkQuartzWindow.h
+@@ -34,6 +34,8 @@
+   NSPoint initialMoveLocation;
+   NSPoint initialResizeLocation;
+   NSRect  initialResizeFrame;
++
++  BOOL    _allowDelegateToBeSetToNil;
+ }
+ 
+ -(BOOL)isInMove;


### PR DESCRIPTION
Cocoa unsets delegates when deallocating the window object, so we need to
allow that and not throw a critical message at that point

Fixes VSTS #935204
Fixes VSTS #935386