### PR TITLE
[2019-02] Another speculative fix for 'pkg-config' sometimes getting built as a…

### DIFF
--- a/bockbuild.py
+++ b/bockbuild.py
@@ -194,8 +194,6 @@ class Bockbuild:
                 self.artifact_root, '%s-%s' % (package.name, arch))
             package.buildstring_file = package.build_artifact + '.buildstring'
             package.log = os.path.join(self.logs, package.name + '.log')
-            if os.path.exists(package.log):
-                delete(package.log)
 
             package.source_dir_name = expand_macros(package.source_dir_name, package)
             workspace_path = os.path.join(self.build_root, package.source_dir_name)
@@ -226,6 +224,8 @@ class Bockbuild:
                 package.deploy_requests.append (stage)
 
         for package in packages.values():
+            if os.path.exists(package.log):
+                delete(package.log)
             package.start_build(arch, dest, stage)
             # make artifact in scratch
             # delete artifact + buildstring

--- a/bockbuild/darwinprofile.py
+++ b/bockbuild/darwinprofile.py
@@ -139,12 +139,12 @@ class DarwinProfile (UnixProfile):
             package.local_ld_flags = ['-arch i386', '-m32']
             package.local_gcc_flags = ['-arch i386', '-m32']
             package.local_configure_flags = [
-                '--build=i386-apple-darwin13.0.0', '--disable-dependency-tracking']
+                '--build=i386-apple-darwin13.0.0', '--host=i386-apple-darwin13.0.0', '--disable-dependency-tracking']
         elif arch == 'darwin-64':
             package.local_ld_flags = ['-arch x86_64 -m64']
             package.local_gcc_flags = ['-arch x86_64 -m64']
             package.local_configure_flags = [
-                '--build=x86_64-apple-darwin13.0.0', '--disable-dependency-tracking']
+                '--build=x86_64-apple-darwin13.0.0', '--host=x86_64-apple-darwin13.0.0', '--disable-dependency-tracking']
         else:
             error('Unknown arch %s' % arch)
 


### PR DESCRIPTION
… 32-bit package regardless of arch configuration

Mono issue: https://github.com/mono/mono/issues/13804

The hypothesis is that at reconfigure using the configure cache file, the lack of explicit setting of the host somehow breaks the build process.

Backport of #98.

/cc @akoeplinger @alexischr