### PR TITLE
[2019-08] Don't force mcs compiler in gtk-sharp.py

### DIFF
--- a/packages/gtk-sharp.py
+++ b/packages/gtk-sharp.py
@@ -9,6 +9,5 @@ class GtkSharp212ReleasePackage (Package):
                              'configure': './bootstrap-2.12 --prefix=%{package_prefix}',
                          }
                          )
-        self.make = 'make CSC=mcs'
 
 GtkSharp212ReleasePackage()


### PR DESCRIPTION
Otherwise we'd revert the work done in https://github.com/mono/gtk-sharp/pull/273.

Discovered in https://github.com/mono/mono/issues/17028.

Backport of #122.

/cc @akoeplinger 