### PR TITLE
Add /usr/local/bin to PATH

### DIFF
--- a/bockbuild/unixprofile.py
+++ b/bockbuild/unixprofile.py
@@ -24,7 +24,7 @@ class UnixProfile (Profile):
                      '%{staged_prefix}/bin',
                      '/usr/bin',
                      '/bin',
-                     '/usr/local/git/bin')
+                     '/usr/local/bin')
 
         self.env.set('C_INCLUDE_PATH',  '%{staged_prefix}/include')
 


### PR DESCRIPTION
So that python3 is found which is needed for the mono build.

I removed /usr/local/git/bin since it doesn't exist on our build bots anyway.