### PR TITLE
[2019-12] Fix 1080409: StackOverflow exception opening Gtk hosted NSView

### DIFF
--- a/packages/gtk+.py
+++ b/packages/gtk+.py
@@ -230,7 +230,8 @@ class GtkPackage (GitHubPackage):
 
                 # https://devdiv.visualstudio.com/DevDiv/_workitems/edit/993471
                 'patches/gtk/gtk-pboard-types.patch',
-                'patches/gtk/define-NSPasteboardTypeURL.patch'
+                'patches/gtk/define-NSPasteboardTypeURL.patch',
+                'patches/gtk/Fix-1080409-StackOverflow-exception-opening-Gtk-host.patch'
             ])
 
     def prep(self):

--- a/packages/patches/gtk/Fix-1080409-StackOverflow-exception-opening-Gtk-host.patch
+++ b/packages/patches/gtk/Fix-1080409-StackOverflow-exception-opening-Gtk-host.patch
@@ -1,0 +1,56 @@
+From 588cba301ee3c43bdaebd41922b7bb60eb85c2ce Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?David=20Karlas=CC=8C?= <david.karlas@gmail.com>
+Date: Thu, 14 May 2020 15:13:56 +0200
+Subject: [PATCH] Fix 1080409: StackOverflow exception opening Gtk hosted
+ NSView
+
+Problem was that if `r.origin.x`/`r.origin.y` were 0, same value was looped until stackoverflow.
+Whole logic of method assumes that it will loop over children hence recursive but in fact it kept passing same NSView over and over again...
+---
+ gdk/quartz/gdkevents-quartz.c | 9 ++++-----
+ 1 file changed, 4 insertions(+), 5 deletions(-)
+
+diff --git a/gdk/quartz/gdkevents-quartz.c b/gdk/quartz/gdkevents-quartz.c
+index a12597d0f9..1734762e5c 100644
+--- a/gdk/quartz/gdkevents-quartz.c
++++ b/gdk/quartz/gdkevents-quartz.c
+@@ -729,9 +729,8 @@ _gdk_quartz_events_send_map_event (GdkWindow *window)
+ }
+ 
+ static NSView *
+-find_nsview_at_pos (GdkWindowImplQuartz *impl, gint x, gint y)
++find_nsview_at_pos (NSView *view, NSView *layer_view, gint x, gint y)
+ {
+-  NSView *view = impl->view;
+   guint n_subviews;
+   guint i;
+ 
+@@ -742,14 +741,14 @@ find_nsview_at_pos (GdkWindowImplQuartz *impl, gint x, gint y)
+       NSView* sv = [[view subviews] objectAtIndex:i];
+       NSRect r = [sv frame];
+ 
+-      if (sv == impl->layer_view)
++      if (sv == layer_view)
+         continue;
+ 
+       if (![sv isHidden] &&
+           r.origin.x <= x && r.origin.x + r.size.width >= x &&
+           r.origin.y <= y && r.origin.y + r.size.height >= y)
+         {
+-          NSView* child = find_nsview_at_pos (impl, x - r.origin.x, y - r.origin.y);
++          NSView* child = find_nsview_at_pos (sv, layer_view, x - r.origin.x, y - r.origin.y);
+           if (child != NULL)
+             return child;
+           else
+@@ -933,7 +932,7 @@ find_window_for_ns_event (NSEvent *nsevent,
+                 toplevel_private = (GdkWindowObject *)toplevel;
+                 toplevel_impl = (GdkWindowImplQuartz *)toplevel_private->impl;
+ 
+-                subview = find_nsview_at_pos (toplevel_impl, x_tmp, y_tmp);
++                subview = find_nsview_at_pos (toplevel_impl->view, toplevel_impl->layer_view, x_tmp, y_tmp);
+                 if (subview != NULL && ![subview isKindOfClass:[GdkQuartzView class]]) {
+                   g_signal_emit_by_name (toplevel, "native-child-event",
+                                          subview, nsevent);
+-- 
+2.21.1 (Apple Git-122.3)
+


### PR DESCRIPTION
Problem was that if `r.origin.x`/`r.origin.y` were 0, same value was looped until stackoverflow.
Whole logic of method assumes that it will loop over children hence recursive but in fact it kept passing same NSView over and over again...

Backport of #159.

/cc @akoeplinger @DavidKarlas