### PR TITLE
[GLib] Avoid keeping a reference to the error

### DIFF
--- a/packages/gtk-sharp.py
+++ b/packages/gtk-sharp.py
@@ -4,7 +4,7 @@ class GtkSharp212ReleasePackage (Package):
         Package.__init__(self, 'gtk-sharp',
                          sources=['git://github.com/mono/gtk-sharp.git'],
                          git_branch='gtk-sharp-2-12-branch',
-                         revision='a915b2c6726b99b58dd5c2ff79c6e825660f4416',
+                         revision='33fabaf9333f6cf26af1682cc67b4cfa99a0fc41',
                          override_properties={
                              'configure': './bootstrap-2.12 --prefix=%{package_prefix}',
                          }


### PR DESCRIPTION
The original impl did not take into account exceptions marshalling across thread boundaries so it could end up with the error being accessed after being disposed
Fix this by querying the message in-place, and also clear the error after, to signal to glib that we've suceeded in recovering

Fixes devdiv.visualstudio.com/DevDiv/_workitems/edit/1247180